### PR TITLE
Add shell script execution support

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -59,6 +59,7 @@ When these directories are not provided explicitly, the runner stores runtime da
 | `AUTOMN_RUNNER_LOCAL_MAX_CONCURRENCY` | Local safeguard limiting simultaneous executions regardless of host configuration. |
 | `AUTOMN_RUNNER_TIMEOUT_MS` | Upper bound (ms) for host → runner HTTP requests. |
 | `AUTOMN_RUNNER_RESET_TOKEN` | Enables the `/internal/reset` endpoint for secret rotation. Provide a long random string. |
+| `AUTOMN_RUNNER_SHELL_PATH` | Custom shell executable for `shell` language scripts (defaults to `bash`/`sh`). |
 | `PORT` / `AUTOMN_RUNNER_PORT` | HTTP listen port (default `3030`). |
 | `PYTHON_VERSION`, `POWERSHELL_VERSION` (build args) | Pin interpreter versions when building the runner Docker image. |
 

--- a/frontend/src/components/SettingsRunnerHosts.jsx
+++ b/frontend/src/components/SettingsRunnerHosts.jsx
@@ -47,6 +47,10 @@ const RUNTIME_ICON_RULES = [
     test: (value) => value.includes("powershell") || value.includes("pwsh"),
     icon: createImageIcon("/powershell.svg", "PowerShell"),
   },
+  {
+    test: (value) => value.includes("shell"),
+    icon: createEmojiIcon("💻"),
+  },
 ];
 
 const DEFAULT_RUNTIME_ICON = createEmojiIcon("⚙️");
@@ -171,6 +175,7 @@ const RUNTIME_DISPLAY_NAMES = {
   python: "Python",
   powershell: "PowerShell",
   pwsh: "PowerShell",
+  shell: "Shell",
 };
 
 const formatRuntimeName = (value) => {


### PR DESCRIPTION
## Summary
- add shell runtime resolution and execution support in the runner
- expose shell runtime configuration, detection, and status visuals
- document the shell interpreter override environment variable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f75a5b9988326b54fcda46f4c5c07)