### PR TITLE
Add shell script selection in script editor

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -59,6 +59,7 @@ When these directories are not provided explicitly, the runner stores runtime da
 | `AUTOMN_RUNNER_LOCAL_MAX_CONCURRENCY` | Local safeguard limiting simultaneous executions regardless of host configuration. |
 | `AUTOMN_RUNNER_TIMEOUT_MS` | Upper bound (ms) for host → runner HTTP requests. |
 | `AUTOMN_RUNNER_RESET_TOKEN` | Enables the `/internal/reset` endpoint for secret rotation. Provide a long random string. |
+| `AUTOMN_RUNNER_SHELL_PATH` | Custom shell executable for `shell` language scripts (defaults to `bash`/`sh`). |
 | `PORT` / `AUTOMN_RUNNER_PORT` | HTTP listen port (default `3030`). |
 | `PYTHON_VERSION`, `POWERSHELL_VERSION` (build args) | Pin interpreter versions when building the runner Docker image. |
 

--- a/frontend/src/components/ScriptEditor.jsx
+++ b/frontend/src/components/ScriptEditor.jsx
@@ -83,13 +83,40 @@ const POWERSHELL_SNIPPETS = [
   },
 ];
 
+const SHELL_SNIPPETS = [
+  {
+    label: "AutomnReturn (success)",
+    value: "AutomnReturn '{\"success\":true,\"data\":null}'\n",
+  },
+  {
+    label: "AutomnLog (info)",
+    value: "AutomnLog \"Starting process\" \"info\"\n",
+  },
+  {
+    label: "AutomnLog (warn)",
+    value: "AutomnLog \"User not found\" \"warn\"\n",
+  },
+  {
+    label: "AutomnLog (error)",
+    value: "AutomnLog \"Critical failure\" \"error\"\n",
+  },
+  {
+    label: "AutomnRunLog",
+    value: "AutomnRunLog \"Debug info\"\n",
+  },
+  {
+    label: "AutomnNotify (Admins)",
+    value: "AutomnNotify \"Admins\" \"Deployment completed\" \"info\"\n",
+  },
+];
+
 const SNIPPETS = {
   node: NODE_SNIPPETS,
   javascript: NODE_SNIPPETS,
   typescript: NODE_SNIPPETS,
   python: PYTHON_SNIPPETS,
   powershell: POWERSHELL_SNIPPETS,
-  shell: [],
+  shell: SHELL_SNIPPETS,
 };
 
 const VARIABLE_WARNING_STORAGE_KEY = "automn.hideVariableSecurityWarning";
@@ -910,6 +937,7 @@ export default function ScriptEditor({
             <option value="node">Node JS</option>
             <option value="python">Python</option>
             <option value="powershell">PowerShell</option>
+            <option value="shell">Shell</option>
           </select>
         </div>
 

--- a/frontend/src/components/ScriptVersions.jsx
+++ b/frontend/src/components/ScriptVersions.jsx
@@ -10,6 +10,8 @@ const mapLanguageToMonaco = (language) => {
       return "python";
     case "powershell":
       return "powershell";
+    case "shell":
+      return "shell";
     default:
       return "javascript";
   }

--- a/frontend/src/components/SettingsCategories.jsx
+++ b/frontend/src/components/SettingsCategories.jsx
@@ -11,6 +11,7 @@ const LANGUAGE_OPTIONS = [
   { value: "node", label: "Node JS" },
   { value: "python", label: "Python" },
   { value: "powershell", label: "PowerShell" },
+  { value: "shell", label: "Shell" },
 ];
 
 const normalizeCategory = (entry) => ({

--- a/frontend/src/components/SettingsRunnerHosts.jsx
+++ b/frontend/src/components/SettingsRunnerHosts.jsx
@@ -47,6 +47,10 @@ const RUNTIME_ICON_RULES = [
     test: (value) => value.includes("powershell") || value.includes("pwsh"),
     icon: createImageIcon("/powershell.svg", "PowerShell"),
   },
+  {
+    test: (value) => value.includes("shell"),
+    icon: createEmojiIcon("💻"),
+  },
 ];
 
 const DEFAULT_RUNTIME_ICON = createEmojiIcon("⚙️");
@@ -171,6 +175,7 @@ const RUNTIME_DISPLAY_NAMES = {
   python: "Python",
   powershell: "PowerShell",
   pwsh: "PowerShell",
+  shell: "Shell",
 };
 
 const formatRuntimeName = (value) => {


### PR DESCRIPTION
## Summary
- allow shell scripts to be chosen when creating scripts or setting collection defaults
- add shell-specific helper snippets and monaco language handling for version diffs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f75a5b9988326b54fcda46f4c5c07)