### PR TITLE
Enhance structured logging for runs

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -37,6 +37,8 @@ The host no longer embeds an execution engine—every script runs on a registere
 
 Log frames are forwarded verbatim; the final `result` payload includes `runId`, `stdout`, `stderr`, `code`, `duration`, `returnData`, `automnLogs`, `automnNotifications`, and the original `input`.
 
+Use `AutomnLog` to emit structured entries with an optional **type** to categorize events beyond success/error. For example, `AutomnLog("Token missing", "warn", { "area": "login" }, "authentication")` creates an authentication-focused log entry that surfaces separately from general run logs.
+
 ## Environment variables
 | Variable | Purpose |
 | --- | --- |

--- a/frontend/src/components/ScriptAnalytics.jsx
+++ b/frontend/src/components/ScriptAnalytics.jsx
@@ -38,6 +38,23 @@ function formatPayload(value) {
   }
 }
 
+function getLogLevelTone(level) {
+  const normalized = (level || "").toLowerCase();
+  if (normalized === "error") return "text-red-400";
+  if (normalized === "warn" || normalized === "warning") return "text-amber-300";
+  if (normalized === "success") return "text-emerald-300";
+  if (normalized === "debug") return "text-indigo-300";
+  return "text-sky-300";
+}
+
+function getLogTypeTone(type) {
+  const normalized = (type || "").toLowerCase();
+  if (normalized === "authentication") {
+    return "border-amber-500/70 bg-amber-900/20 text-amber-200";
+  }
+  return "border-slate-700 bg-slate-900/60 text-slate-300";
+}
+
 function getMethodBadgeTone(method) {
   const normalized = (method || "").toUpperCase();
   const baseClasses =
@@ -317,17 +334,18 @@ export default function ScriptAnalytics({
                         className="rounded border border-slate-800 bg-slate-950/50 p-2"
                       >
                         <div className="flex items-center justify-between text-xs">
-                          <span
-                            className={`font-semibold uppercase ${
-                              log.level === "error"
-                                ? "text-red-400"
-                                : log.level === "warn"
-                                ? "text-amber-300"
-                                : "text-sky-300"
-                            }`}
-                          >
-                            {log.level || "info"}
-                          </span>
+                          <div className="flex items-center gap-2">
+                            <span
+                              className={`font-semibold uppercase ${getLogLevelTone(log.level)}`}
+                            >
+                              {log.level || "info"}
+                            </span>
+                            <span
+                              className={`rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${getLogTypeTone(log.type)}`}
+                            >
+                              {log.type || "general"}
+                            </span>
+                          </div>
                           <span className="font-mono text-[11px] text-slate-500">
                             {log.timestamp ? formatDate(log.timestamp) : `#${log.order ?? index + 1}`}
                           </span>

--- a/frontend/src/components/ScriptEditor.jsx
+++ b/frontend/src/components/ScriptEditor.jsx
@@ -20,6 +20,10 @@ const NODE_SNIPPETS = [
     value: "AutomnLog(\"Critical failure\", \"error\");\n",
   },
   {
+    label: "AutomnLog (authentication)",
+    value: "AutomnLog(\"Token missing\", \"warn\", { area: \"login\" }, \"authentication\");\n",
+  },
+  {
     label: "AutomnRunLog",
     value: "AutomnRunLog(\"Debug info\", { context: \"runner\" });\n",
   },
@@ -45,6 +49,10 @@ const PYTHON_SNIPPETS = [
   {
     label: "AutomnLog (error)",
     value: "AutomnLog(\"Critical failure\", \"error\")\n",
+  },
+  {
+    label: "AutomnLog (authentication)",
+    value: "AutomnLog(\"Token missing\", \"warn\", {\"area\": \"login\"}, \"authentication\")\n",
   },
   {
     label: "AutomnRunLog",
@@ -74,6 +82,10 @@ const POWERSHELL_SNIPPETS = [
     value: "AutomnLog \"Critical failure\" \"error\"\n",
   },
   {
+    label: "AutomnLog (authentication)",
+    value: "AutomnLog \"Token missing\" \"warn\" @{ area = \"login\" } \"authentication\"\n",
+  },
+  {
     label: "AutomnRunLog",
     value: "AutomnRunLog \"Debug info\" @{ context = \"runner\" }\n",
   },
@@ -99,6 +111,10 @@ const SHELL_SNIPPETS = [
   {
     label: "AutomnLog (error)",
     value: "AutomnLog \"Critical failure\" \"error\"\n",
+  },
+  {
+    label: "AutomnLog (authentication)",
+    value: "AutomnLog \"Token missing\" \"warn\" '{\"area\":\"login\"}' \"authentication\"\n",
   },
   {
     label: "AutomnRunLog",

--- a/server.js
+++ b/server.js
@@ -959,6 +959,50 @@ async function determineCodeVersionForScript(scriptId) {
 }
 
 function normalizeRunResultPayload(result, context) {
+  const normalizeLevel = (value) => {
+    const normalized = typeof value === "string" ? value.toLowerCase().trim() : "";
+    if (normalized === "warn" || normalized === "warning") return "warn";
+    if (normalized === "error") return "error";
+    if (normalized === "success") return "success";
+    if (normalized === "debug") return "debug";
+    return "info";
+  };
+
+  const normalizeLogContext = (value) => {
+    if (value && typeof value === "object" && !Array.isArray(value)) return value;
+    if (value === undefined || value === null) return {};
+    return { value };
+  };
+
+  const normalizeLogType = (value) => {
+    const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+    return normalized || "general";
+  };
+
+  const normalizeAutomnLog = (log, index) => {
+    const messageValue =
+      log?.message === null || log?.message === undefined ? "" : log.message;
+    const timestamp =
+      typeof log?.timestamp === "string" && log.timestamp.trim()
+        ? log.timestamp
+        : new Date().toISOString();
+
+    return {
+      message: typeof messageValue === "string" ? messageValue : String(messageValue),
+      level: normalizeLevel(log?.level),
+      type: normalizeLogType(log?.type ?? log?.category),
+      context: normalizeLogContext(log?.context),
+      order: Number.isFinite(log?.order) ? log.order : index,
+      timestamp,
+    };
+  };
+
+  const normalizeAutomnLogs = (logs) => {
+    const parsedLogs = ensureArray(logs);
+    if (!parsedLogs.length) return [];
+    return parsedLogs.map((log, idx) => normalizeAutomnLog(log, idx));
+  };
+
   const fallbackDuration = Math.max(Date.now() - context.startTimestamp, 0);
   const rawCode = result?.code;
   const numericCodeCandidate = Number.isFinite(rawCode)
@@ -985,16 +1029,107 @@ function normalizeRunResultPayload(result, context) {
       result && Object.prototype.hasOwnProperty.call(result, "returnData")
         ? result.returnData
         : null,
-    automnLogs: ensureArray(result?.automnLogs),
+    automnLogs: normalizeAutomnLogs(result?.automnLogs),
     automnNotifications: ensureArray(result?.automnNotifications),
     input:
       result && Object.prototype.hasOwnProperty.call(result, "input")
         ? result.input
         : context.inputSnapshot,
+    httpMethod: context.httpMethod || null,
+    scriptId: context.scriptId || null,
+    errorCode:
+      typeof result?.errorCode === "string"
+        ? result.errorCode
+        : typeof result?.code === "string"
+          ? result.code
+          : null,
   };
 
   if (!normalized.runId) normalized.runId = context.runId;
   return normalized;
+}
+
+function buildFallbackAutomnLogs({
+  success,
+  failureReason,
+  errorCode,
+  context,
+}) {
+  const reasonText = typeof failureReason === "string" ? failureReason : "";
+  const normalizedErrorCode =
+    typeof errorCode === "string" ? errorCode.toLowerCase().trim() : "";
+  const authenticationCodes = new Set(["missing_token", "invalid_token", "unauthorized"]);
+  const isAuthenticationIssue =
+    authenticationCodes.has(normalizedErrorCode) ||
+    reasonText.toLowerCase().includes("authentication");
+
+  const type = isAuthenticationIssue ? "authentication" : "general";
+  const level = success ? "success" : isAuthenticationIssue ? "warn" : "error";
+  const message = success ? "Run completed successfully" : reasonText || "Run failed";
+
+  const fallbackContext = {};
+  if (context?.httpMethod) fallbackContext.httpMethod = context.httpMethod;
+  if (context?.scriptId) fallbackContext.scriptId = context.scriptId;
+  if (context?.runId) fallbackContext.runId = context.runId;
+
+  return [
+    {
+      message,
+      level,
+      type,
+      context: fallbackContext,
+      order: 0,
+      timestamp: new Date().toISOString(),
+    },
+  ];
+}
+
+function normalizeAutomnLogCollection(logs, fallbackDetails) {
+  const parsedLogs = ensureArray(logs);
+  if (!parsedLogs.length) {
+    return buildFallbackAutomnLogs(fallbackDetails);
+  }
+  return parsedLogs.map((log, idx) => {
+    const messageValue =
+      log?.message === null || log?.message === undefined ? "" : log.message;
+    const levelValue =
+      typeof log?.level === "string" ? log.level.toLowerCase().trim() : "";
+    const normalizedLevel =
+      levelValue === "warn" ||
+      levelValue === "warning" ||
+      levelValue === "error" ||
+      levelValue === "success" ||
+      levelValue === "debug"
+        ? levelValue === "warning"
+          ? "warn"
+          : levelValue
+        : "info";
+    const typeValue =
+      typeof log?.type === "string"
+        ? log.type.trim().toLowerCase()
+        : typeof log?.category === "string"
+          ? log.category.trim().toLowerCase()
+          : "";
+    const normalizedContext =
+      log?.context && typeof log.context === "object" && !Array.isArray(log.context)
+        ? log.context
+        : log?.context === undefined || log?.context === null
+          ? {}
+          : { value: log.context };
+    const timestamp =
+      typeof log?.timestamp === "string" && log.timestamp.trim()
+        ? log.timestamp
+        : new Date().toISOString();
+
+    return {
+      message: typeof messageValue === "string" ? messageValue : String(messageValue),
+      level: normalizedLevel,
+      type: typeValue || "general",
+      context: normalizedContext,
+      order: Number.isFinite(log?.order) ? log.order : idx,
+      timestamp,
+    };
+  });
 }
 
 async function createRunTracker({
@@ -1068,6 +1203,16 @@ async function createRunTracker({
       trimmedStderr || (normalized.code !== 0 ? "Script execution failed" : "");
 
     normalized.stderr = persistedStderr;
+    normalized.automnLogs = normalizeAutomnLogCollection(normalized.automnLogs, {
+      success,
+      failureReason: persistedStderr,
+      errorCode: normalized.errorCode,
+      context: {
+        httpMethod: normalized.httpMethod || context.httpMethod || null,
+        scriptId,
+        runId: normalized.runId,
+      },
+    });
     let returnJson = "null";
     try {
       returnJson = JSON.stringify(normalized.returnData);
@@ -1136,6 +1281,7 @@ async function createRunTracker({
         automnLogs: [],
         automnNotifications: [],
         input: inputSnapshot,
+        errorCode: failureError?.code,
       });
     },
   };


### PR DESCRIPTION
## Summary
- add support for typed AutomnLog entries (including authentication) across runner helpers and host normalization
- generate fallback structured logs for run outcomes so analytics capture more than success/error states
- surface log type styling/examples in the UI and runner docs

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693523c00e4c832699f5c38b5ace1d05)