### PR TITLE
Add consolidated log viewer in settings

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import SettingsRunnerHosts from "./components/SettingsRunnerHosts";
 import SettingsData from "./components/SettingsData";
 import SettingsCategories from "./components/SettingsCategories";
 import SettingsGlobalVariables from "./components/SettingsGlobalVariables";
+import SettingsLogs from "./components/SettingsLogs";
 import { apiRequest } from "./utils/api";
 import { DEFAULT_THEME_ID, THEMES, THEME_ORDER } from "./utils/themes";
 
@@ -141,6 +142,7 @@ const SETTINGS_TABS = [
   { id: "collections", label: "Collections" },
   { id: "global-variables", label: "Global Variables" },
   { id: "data", label: "Data" },
+  { id: "logs", label: "Logs" },
   { id: "users", label: "Users" },
   { id: "runners", label: "Runners" },
 ];
@@ -3224,6 +3226,9 @@ export default function App() {
                 {settingsTab === "data" && currentUser?.isAdmin && (
                   <SettingsData onAuthError={handleAuthError} />
                 )}
+                {settingsTab === "logs" && (
+                  <SettingsLogs onAuthError={handleAuthError} />
+                )}
                 {settingsTab === "users" && currentUser?.isAdmin && (
                   <SettingsUsers
                     currentUser={currentUser}
@@ -3233,7 +3238,7 @@ export default function App() {
                 {settingsTab === "runners" && currentUser?.isAdmin && (
                   <SettingsRunnerHosts onAuthError={handleAuthError} />
                 )}
-                {!["ui", "collections", "global-variables", "data", "users", "runners"].includes(
+                {!["ui", "collections", "global-variables", "data", "logs", "users", "runners"].includes(
                   settingsTab,
                 ) && (
                     <div className="flex h-full items-center justify-center rounded border border-dashed border-slate-800 bg-slate-900/40 p-6 text-center text-sm text-slate-400">


### PR DESCRIPTION
## Summary
- add a consolidated logs API that filters entries to scripts the user can access and supports query filters
- introduce a Logs settings tab with search and filtering for script, collection, status, HTTP type, and error tag
- surface recent log details with request type, results, and tags in a centralized table view

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693553d36a388326a54fb28147246793)