### PR TITLE
Restyle logs settings page

### DIFF
--- a/frontend/src/components/SettingsLogs.jsx
+++ b/frontend/src/components/SettingsLogs.jsx
@@ -215,20 +215,20 @@ export default function SettingsLogs({ onAuthError }) {
   };
 
   return (
-    <div className="flex h-full flex-col gap-4">
+    <div className="flex h-full flex-col gap-5">
       <div className="space-y-2">
-        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Consolidated Logs</h3>
-        <p className="text-sm text-slate-600 dark:text-slate-400">
-          Review recent activity across the scripts you can access. Filter by collection, script, HTTP
-          method, result, or error tag, and search within log summaries.
+        <h3 className="text-lg font-semibold text-slate-100">Consolidated Logs</h3>
+        <p className="text-sm text-slate-400">
+          Review recent activity across the scripts you can access. Filter by collection, script, HTTP method, result,
+          or error tag, and search within log summaries.
         </p>
       </div>
 
-      <div className="grid grid-cols-1 gap-3 rounded border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-800 dark:bg-slate-900/60 md:grid-cols-3 lg:grid-cols-6">
-        <label className="space-y-1 text-sm text-slate-700 dark:text-slate-300">
-          <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Collection</span>
+      <div className="grid grid-cols-1 gap-3 rounded-xl border border-slate-800/80 bg-slate-950/60 p-4 shadow-lg shadow-slate-950/50 md:grid-cols-3 lg:grid-cols-6">
+        <label className="space-y-1 text-sm text-slate-200">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Collection</span>
           <select
-            className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-sky-500 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+            className="w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
             value={filters.collectionId}
             onChange={(event) => handleFilterChange("collectionId", event.target.value)}
           >
@@ -240,10 +240,10 @@ export default function SettingsLogs({ onAuthError }) {
           </select>
         </label>
 
-        <label className="space-y-1 text-sm text-slate-700 dark:text-slate-300">
-          <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Script</span>
+        <label className="space-y-1 text-sm text-slate-200">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Script</span>
           <select
-            className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-sky-500 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+            className="w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
             value={filters.scriptId}
             onChange={(event) => handleFilterChange("scriptId", event.target.value)}
           >
@@ -255,10 +255,10 @@ export default function SettingsLogs({ onAuthError }) {
           </select>
         </label>
 
-        <label className="space-y-1 text-sm text-slate-700 dark:text-slate-300">
-          <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Result</span>
+        <label className="space-y-1 text-sm text-slate-200">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Result</span>
           <select
-            className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-sky-500 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+            className="w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
             value={filters.result}
             onChange={(event) => handleFilterChange("result", event.target.value)}
           >
@@ -270,10 +270,10 @@ export default function SettingsLogs({ onAuthError }) {
           </select>
         </label>
 
-        <label className="space-y-1 text-sm text-slate-700 dark:text-slate-300">
-          <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">HTTP Type</span>
+        <label className="space-y-1 text-sm text-slate-200">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">HTTP Type</span>
           <select
-            className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-sky-500 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+            className="w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
             value={filters.httpType}
             onChange={(event) => handleFilterChange("httpType", event.target.value)}
           >
@@ -285,10 +285,10 @@ export default function SettingsLogs({ onAuthError }) {
           </select>
         </label>
 
-        <label className="space-y-1 text-sm text-slate-700 dark:text-slate-300">
-          <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Error Tag</span>
+        <label className="space-y-1 text-sm text-slate-200">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Error Tag</span>
           <select
-            className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-sky-500 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+            className="w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
             value={filters.errorTag}
             onChange={(event) => handleFilterChange("errorTag", event.target.value)}
           >
@@ -300,28 +300,28 @@ export default function SettingsLogs({ onAuthError }) {
           </select>
         </label>
 
-        <label className="space-y-1 text-sm text-slate-700 dark:text-slate-300">
-          <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Search</span>
+        <label className="space-y-1 text-sm text-slate-200">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Search</span>
           <input
             type="search"
             placeholder="Search logs, scripts, tags"
-            className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-sky-500 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+            className="w-full rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 transition focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
             value={filters.search}
             onChange={(event) => handleFilterChange("search", event.target.value)}
           />
         </label>
       </div>
 
-      <div className="flex-1 rounded border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
-        <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-slate-800">
+      <div className="flex-1 rounded-2xl border border-slate-800/80 bg-slate-950/70 shadow-xl shadow-slate-950/50">
+        <div className="flex items-center justify-between border-b border-slate-800/80 px-5 py-4">
           <div>
-            <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-300">Log Events</h4>
-            <p className="text-xs text-slate-500 dark:text-slate-500">
+            <h4 className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">Log Events</h4>
+            <p className="text-sm text-slate-300">
               Showing {events.length} entr{events.length === 1 ? "y" : "ies"} matching your filters.
             </p>
           </div>
           <button
-            className="rounded border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-900 hover:border-sky-500 hover:text-sky-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:text-sky-200"
+            className="rounded-lg bg-gradient-to-r from-sky-500 to-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:shadow-lg hover:shadow-sky-500/30 disabled:cursor-not-allowed disabled:opacity-60"
             type="button"
             onClick={loadEvents}
             disabled={isLoading}
@@ -331,13 +331,13 @@ export default function SettingsLogs({ onAuthError }) {
         </div>
 
         {error && (
-          <div className="border-b border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800 dark:border-rose-800/50 dark:bg-rose-900/30 dark:text-rose-200">
+          <div className="border-b border-rose-800/50 bg-rose-950/40 px-4 py-3 text-sm text-rose-100">
             {error}
           </div>
         )}
 
         <div className="overflow-auto">
-          <div className="grid min-w-[760px] grid-cols-[1.6fr_1.4fr_1fr_1fr_1fr] border-b border-slate-200 bg-slate-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 dark:border-slate-800/80 dark:bg-slate-800/60 dark:text-slate-300">
+          <div className="grid min-w-[760px] grid-cols-[1.6fr_1.4fr_1fr_1fr_1fr] border-b border-slate-800/80 bg-slate-900/80 px-5 py-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-300">
             <div>Datetime</div>
             <div>Script</div>
             <div>Request Type</div>
@@ -346,9 +346,9 @@ export default function SettingsLogs({ onAuthError }) {
           </div>
 
           {isLoading ? (
-            <div className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">Loading logs...</div>
+            <div className="px-5 py-6 text-center text-sm text-slate-400">Loading logs...</div>
           ) : events.length === 0 ? (
-            <div className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+            <div className="px-5 py-6 text-center text-sm text-slate-400">
               No log events match your filters yet.
             </div>
           ) : (
@@ -357,19 +357,19 @@ export default function SettingsLogs({ onAuthError }) {
                 key={event.runId}
                 type="button"
                 onClick={() => setSelectedEvent(event)}
-                className="grid min-w-[760px] grid-cols-[1.6fr_1.4fr_1fr_1fr_1fr] items-center border-b border-slate-200 px-4 py-3 text-left text-sm text-slate-900 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500/60 dark:border-slate-800/60 dark:text-slate-100 dark:hover:bg-slate-800/40"
+                className="grid min-w-[760px] grid-cols-[1.6fr_1.4fr_1fr_1fr_1fr] items-center border-b border-slate-800/60 px-5 py-3 text-left text-sm text-slate-100 transition hover:bg-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
               >
-                <div className="space-y-1 text-slate-900 dark:text-slate-200">
-                  <div className="font-medium">{formatDateTime(event.timestamp)}</div>
+                <div className="space-y-1 text-slate-200">
+                  <div className="font-semibold">{formatDateTime(event.timestamp)}</div>
                   {event.message ? (
-                    <div className="line-clamp-1 text-xs text-slate-500 dark:text-slate-400" title={event.message}>
+                    <div className="line-clamp-1 text-xs text-slate-400" title={event.message}>
                       {event.message}
                     </div>
                   ) : null}
                 </div>
                 <div className="space-y-1">
-                  <div className="font-semibold text-slate-900 dark:text-slate-100">{event.scriptName}</div>
-                  <div className="text-xs text-slate-500 dark:text-slate-400">{event.collectionName}</div>
+                  <div className="font-semibold text-slate-100">{event.scriptName}</div>
+                  <div className="text-xs text-slate-400">{event.collectionName}</div>
                 </div>
                 <div>
                   <RequestBadge method={event.httpType} fallback={event.requestType} />
@@ -387,17 +387,17 @@ export default function SettingsLogs({ onAuthError }) {
       </div>
 
       {selectedEvent ? (
-        <div className="rounded border border-slate-200 bg-white p-4 shadow-xl dark:border-slate-800 dark:bg-slate-900/80">
-          <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="rounded-2xl border border-slate-800/80 bg-slate-950/80 p-5 shadow-xl shadow-slate-950/50">
+          <div className="mb-4 flex items-start justify-between gap-3">
             <div>
-              <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Log Details</p>
-              <h5 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{selectedEvent.scriptName}</h5>
-              <p className="text-sm text-slate-600 dark:text-slate-400">{selectedEvent.collectionName}</p>
+              <p className="text-[11px] uppercase tracking-[0.08em] text-slate-400">Log Details</p>
+              <h5 className="text-xl font-semibold text-slate-50">{selectedEvent.scriptName}</h5>
+              <p className="text-sm text-slate-400">{selectedEvent.collectionName}</p>
             </div>
             <button
               type="button"
               onClick={() => setSelectedEvent(null)}
-              className="rounded border border-slate-300 bg-white px-3 py-1 text-sm font-semibold text-slate-900 hover:border-sky-500 hover:text-sky-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:text-sky-200"
+              className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-1.5 text-sm font-semibold text-slate-100 transition hover:border-sky-500 hover:text-sky-200"
             >
               Close
             </button>
@@ -412,9 +412,9 @@ export default function SettingsLogs({ onAuthError }) {
                 <div className="space-y-1">
                   <RequestBadge method={selectedEvent.httpType} fallback={selectedEvent.requestOrigin} />
                   {selectedEvent.triggeredByUserName ? (
-                    <p className="text-xs text-slate-500 dark:text-slate-400">Triggered by {selectedEvent.triggeredByUserName}</p>
+                    <p className="text-xs text-slate-400">Triggered by {selectedEvent.triggeredByUserName}</p>
                   ) : selectedEvent.triggeredBy ? (
-                    <p className="text-xs text-slate-500 dark:text-slate-400">Triggered by {selectedEvent.triggeredBy}</p>
+                    <p className="text-xs text-slate-400">Triggered by {selectedEvent.triggeredBy}</p>
                   ) : null}
                 </div>
               }
@@ -430,16 +430,16 @@ export default function SettingsLogs({ onAuthError }) {
                     ))}
                   </div>
                 ) : (
-                  <span className="text-slate-400">None</span>
+                  <span className="text-slate-500">None</span>
                 )
               }
             />
           </dl>
 
           {selectedEvent.message ? (
-            <div className="mt-4 rounded border border-slate-200 bg-slate-50 p-3 text-sm text-slate-900 dark:border-slate-800 dark:bg-slate-950/40 dark:text-slate-100">
-              <p className="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-500">Message</p>
-              <p className="whitespace-pre-wrap text-slate-900 dark:text-slate-100">{selectedEvent.message}</p>
+            <div className="mt-4 rounded-lg border border-slate-800/70 bg-slate-900/70 p-4 text-sm text-slate-100 shadow-inner shadow-slate-950/40">
+              <p className="text-[11px] uppercase tracking-[0.08em] text-slate-400">Message</p>
+              <p className="whitespace-pre-wrap text-slate-100">{selectedEvent.message}</p>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary
- refresh the logs filters, table, and detail panel to match the darker Automn settings theme
- update buttons, typography, and backgrounds for more consistent styling across the logs view

## Testing
- npm --prefix frontend run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69356212bd308326aceba9c8aec7b4d0)