### PR TITLE
Handle scheduler script list arrays

### DIFF
--- a/frontend/src/components/SettingsScheduler.jsx
+++ b/frontend/src/components/SettingsScheduler.jsx
@@ -162,7 +162,11 @@ export default function SettingsScheduler({ onAuthError }) {
   const loadScripts = async () => {
     try {
       const response = await apiRequest("/api/scripts");
-      const items = Array.isArray(response.scripts) ? response.scripts : [];
+      const items = Array.isArray(response)
+        ? response
+        : Array.isArray(response.scripts)
+          ? response.scripts
+          : [];
       setScripts(items);
     } catch (err) {
       handleAuthError(err);


### PR DESCRIPTION
## Summary
- handle /api/scripts responses that return a plain array so scheduler script options populate
- keep scheduler job form using the available scripts list for selection

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693653da86188326b4dd230139b5c11f)