### PR TITLE
Fix scheduler job list refresh after schedule changes

### DIFF
--- a/frontend/src/components/SettingsScheduler.jsx
+++ b/frontend/src/components/SettingsScheduler.jsx
@@ -205,20 +205,28 @@ export default function SettingsScheduler({ onAuthError }) {
       };
 
       if (editingId) {
-        await apiRequest(`/api/settings/scheduler/jobs/${editingId}`, {
+        const response = await apiRequest(`/api/settings/scheduler/jobs/${editingId}`, {
           method: "PATCH",
           body: payload,
         });
+        if (response?.job) {
+          setJobs((prev) =>
+            prev.map((job) => (job.id === response.job.id ? response.job : job)),
+          );
+        }
         showNotification({
           title: "Scheduler job updated",
           description: "Changes were saved successfully.",
           tone: "success",
         });
       } else {
-        await apiRequest("/api/settings/scheduler/jobs", {
+        const response = await apiRequest("/api/settings/scheduler/jobs", {
           method: "POST",
           body: payload,
         });
+        if (response?.job) {
+          setJobs((prev) => [response.job, ...prev]);
+        }
         showNotification({
           title: "Scheduler job created",
           description: "The job has been added to the queue.",
@@ -274,6 +282,7 @@ export default function SettingsScheduler({ onAuthError }) {
       await apiRequest(`/api/settings/scheduler/jobs/${job.id}`, {
         method: "DELETE",
       });
+      setJobs((prev) => prev.filter((item) => item.id !== job.id));
       await loadScheduler();
       if (editingId === job.id) {
         resetForm();


### PR DESCRIPTION
## Summary
- update scheduler job handlers to apply API responses directly to the in-memory job list
- remove deleted jobs from local state while keeping the scheduler data reload in place for consistency

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69365830a2d48326b96da959db439e43)