### PR TITLE
Fix scheduler dispatch script loading

### DIFF
--- a/server.js
+++ b/server.js
@@ -1833,13 +1833,19 @@ async function dispatchSchedulerJob(jobRow, { testRun = false } = {}) {
 
   let script;
   try {
-    script = await ensureScriptAccess({
+    const access = await ensureScriptAccess({
       scriptId,
       user: schedulerUser,
       requiredPermission: "run",
     });
+    script = access?.script;
   } catch (err) {
     console.error(`Scheduled job ${jobRow.id} could not load script`, err);
+    return null;
+  }
+
+  if (!script) {
+    console.error(`Scheduled job ${jobRow.id} script is unavailable.`);
     return null;
   }
 


### PR DESCRIPTION
## Summary
- ensure scheduler dispatch extracts the script from the access check result
- fail fast when the scheduler cannot load a script before dispatching

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366130bb748326990847f566cd0da8)