### PR TITLE
Fix settings tab restoration on refresh

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -160,6 +160,32 @@ const ADMIN_ONLY_SETTINGS_TABS = new Set([
 
 const LOGIN_THEME_ID = "automn";
 
+const SETTINGS_HASH_PREFIX = "#settings";
+
+const readSettingsStateFromHash = () => {
+  if (typeof window === "undefined") {
+    return { isOpen: false, tab: "ui" };
+  }
+
+  const hash = window.location.hash || "";
+  if (!hash.startsWith(SETTINGS_HASH_PREFIX)) {
+    return { isOpen: false, tab: "ui" };
+  }
+
+  const tabId = hash.replace(SETTINGS_HASH_PREFIX, "").replace(/^-/u, "") || "ui";
+  const isValidTab = SETTINGS_TABS.some((tab) => tab.id === tabId);
+
+  return {
+    isOpen: true,
+    tab: isValidTab ? tabId : "ui",
+  };
+};
+
+const buildSettingsHash = (tabId) => {
+  const suffix = tabId ? `-${tabId}` : "";
+  return `${SETTINGS_HASH_PREFIX}${suffix}`;
+};
+
 const normalizeRunnerHost = (host) => {
   if (!host || typeof host !== "object") {
     return null;
@@ -388,8 +414,9 @@ export default function App() {
   const [activeDraftId, setActiveDraftId] = useState(null);
   const [isDraftInitializing, setIsDraftInitializing] = useState(false);
   const [draftError, setDraftError] = useState("");
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [settingsTab, setSettingsTab] = useState("ui");
+  const initialSettingsState = readSettingsStateFromHash();
+  const [isSettingsOpen, setIsSettingsOpen] = useState(initialSettingsState.isOpen);
+  const [settingsTab, setSettingsTab] = useState(initialSettingsState.tab);
   const [routeEndpoint, setRouteEndpoint] = useState(() => readRouteEndpoint());
   const [hasLoadedScripts, setHasLoadedScripts] = useState(false);
   const [isRunModalOpen, setIsRunModalOpen] = useState(false);
@@ -442,6 +469,8 @@ export default function App() {
   }, [currentUser]);
 
   useEffect(() => {
+    if (!authChecked) return;
+
     const hasActiveTab = visibleSettingsTabs.some((tab) => tab.id === settingsTab);
     if (!hasActiveTab) {
       const fallbackTab = visibleSettingsTabs[0]?.id || "ui";
@@ -449,7 +478,7 @@ export default function App() {
         setSettingsTab(fallbackTab);
       }
     }
-  }, [visibleSettingsTabs, settingsTab]);
+  }, [authChecked, visibleSettingsTabs, settingsTab]);
 
   const supportsPackageManagement = useMemo(() => {
     if (!selected?.id) {
@@ -1087,7 +1116,6 @@ export default function App() {
 
   const openSettings = useCallback(() => {
     setIsSettingsOpen(true);
-    setSettingsTab("ui");
     setSelected(null);
     setIsCreating(false);
     setIsRecycleOpen(false);
@@ -1111,6 +1139,37 @@ export default function App() {
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
   }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const handleHashChange = () => {
+      const { isOpen, tab } = readSettingsStateFromHash();
+      setIsSettingsOpen(isOpen);
+      if (isOpen) {
+        setSettingsTab(tab);
+      }
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const currentHash = window.location.hash || "";
+    if (isSettingsOpen) {
+      const targetHash = buildSettingsHash(settingsTab);
+      if (currentHash !== targetHash) {
+        const newUrl = `${window.location.pathname}${window.location.search}${targetHash}`;
+        window.history.replaceState({}, "", newUrl);
+      }
+    } else if (currentHash.startsWith(SETTINGS_HASH_PREFIX)) {
+      const newUrl = `${window.location.pathname}${window.location.search}`;
+      window.history.replaceState({}, "", newUrl);
+    }
+  }, [isSettingsOpen, settingsTab]);
 
   const getCategoryKey = useCallback(
     (categoryName) => (categoryName?.trim() || "General").toLowerCase(),


### PR DESCRIPTION
## Summary
- wait for authentication state before forcing a fallback settings tab so hash-selected tabs persist
- preserve admin-accessible settings tabs across page refreshes when addressed via URL hash

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376337a1ec832696c8ff63f40889c4)