### PR TITLE
Persist selected theme across refresh

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -250,8 +250,36 @@ const VALID_SIDEBAR_ICON_IDS = new Set(
   SIDEBAR_ICON_OPTIONS.map((option) => option.id),
 );
 
+const THEME_STORAGE_KEY = "ui.theme.last";
+
+const readStoredThemeId = () => {
+  if (typeof window === "undefined") return null;
+  try {
+    const storedThemeId = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (typeof storedThemeId === "string" && THEMES[storedThemeId]) {
+      return storedThemeId;
+    }
+  } catch (err) {
+    console.error("Failed to read cached theme preference", err);
+  }
+  return null;
+};
+
+const persistStoredThemeId = (themeId) => {
+  if (typeof window === "undefined") return;
+  try {
+    if (THEMES[themeId]) {
+      window.localStorage.setItem(THEME_STORAGE_KEY, themeId);
+    } else {
+      window.localStorage.removeItem(THEME_STORAGE_KEY);
+    }
+  } catch (err) {
+    console.error("Failed to persist theme preference", err);
+  }
+};
+
 const getDefaultUiPreferences = () => ({
-  themeId: DEFAULT_THEME_ID,
+  themeId: readStoredThemeId() || DEFAULT_THEME_ID,
   sidebarIconStyle: "icons-left",
   systemIcons: { ...SYSTEM_ICON_DEFAULTS },
   showSidebarEndpoints: true,
@@ -394,7 +422,7 @@ const buildPathForEndpoint = (endpoint) =>
 
 export default function App() {
   const { confirm, alert } = useNotificationDialog();
-  const [themeId, setThemeId] = useState(DEFAULT_THEME_ID);
+  const [themeId, setThemeId] = useState(() => readStoredThemeId() || DEFAULT_THEME_ID);
   const [scripts, setScripts] = useState([]);
   const [categories, setCategories] = useState([]);
   const [selected, setSelected] = useState(null);
@@ -1094,6 +1122,11 @@ export default function App() {
       document.documentElement.dataset.theme = resolvedThemeId;
     }
   }, [resolvedThemeId]);
+
+  useEffect(() => {
+    if (!currentUser || isChangingPassword) return;
+    persistStoredThemeId(activeThemeId);
+  }, [activeThemeId, currentUser, isChangingPassword]);
 
   useEffect(() => {
     if (activeTab === "security" && !selected?.permissions?.manage) {


### PR DESCRIPTION
## Summary
- load UI theme preference from local storage when initializing preferences
- persist the active theme locally for authenticated sessions to avoid reversion on refresh

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693768fa00cc8326863d6bfeef9fffee)