### PR TITLE
Add typed HTTP response support for `AutomnReturn` and update docs/UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,21 @@ AutomnLog("Testing if " + process.env.AUTOMN_JOB_VAR_TARGET_RUNNER + " will run 
 AutomnReturn({ success: true, message: "That couldn't have gone any better!" });
 ```
 
+`AutomnReturn` also supports typed HTTP responses when you need something other than the default JSON wrapper. For example:
+
+```js
+AutomnReturn({ type: "redirect", status: 302, location: "https://example.com" });
+AutomnReturn({ type: "text", body: "Plain-text response" });
+AutomnReturn({
+  type: "binary",
+  headers: {
+    "Content-Type": "application/pdf",
+  },
+  downloadName: "report.pdf",
+  base64: Buffer.from("hello world").toString("base64"),
+});
+```
+
 - Select **Run Script**, leave it as is (POST is fine) and click **RUN SCRIPT** or browse to: http://<Automn Host IP>:8088/s/test-endpoint to trigger the script
 - Check the analytics tab, you should see a success posting with a return payload of:
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -37,6 +37,26 @@ The host no longer embeds an execution engine—every script runs on a registere
 
 Log frames are forwarded verbatim; the final `result` payload includes `runId`, `stdout`, `stderr`, `code`, `duration`, `returnData`, `automnLogs`, `automnNotifications`, and the original `input`.
 
+`AutomnReturn(...)` still accepts ordinary JSON-serializable values, but it can now also return typed HTTP response descriptors for `/s/<endpoint>` calls. Supported descriptor types are:
+- `json` → send a JSON body directly
+- `text` → send plain text
+- `html` → send HTML
+- `redirect` → set `Location` and return the provided redirect status
+- `binary` → decode a base64 payload and stream it with your chosen headers
+- `empty` → send no body
+
+Example Node.js responses:
+```js
+AutomnReturn({ type: "redirect", status: 302, location: "https://example.com" });
+AutomnReturn({ type: "text", body: "Plain-text response" });
+AutomnReturn({
+  type: "binary",
+  headers: { "Content-Type": "application/pdf" },
+  downloadName: "report.pdf",
+  base64: Buffer.from("hello world").toString("base64"),
+});
+```
+
 Use `AutomnLog` to emit structured entries with an optional **type** to categorize events beyond success/error. For example, `AutomnLog("Token missing", "warn", { "area": "login" }, "authentication")` creates an authentication-focused log entry that surfaces separately from general run logs.
 
 ## Environment variables

--- a/frontend/src/components/ScriptEditor.jsx
+++ b/frontend/src/components/ScriptEditor.jsx
@@ -2,169 +2,246 @@ import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import Editor from "@monaco-editor/react";
 import { apiRequest } from "../utils/api";
 
-const NODE_SNIPPETS = [
-  {
-    label: "AutomnReturn (JSON)",
-    value: "AutomnReturn({ success: true, data: null });\n",
-  },
-  {
-    label: "AutomnReturn (redirect)",
-    value: "AutomnReturn({ type: \"redirect\", status: 302, location: \"https://example.com\" });\n",
-  },
-  {
-    label: "AutomnReturn (text)",
-    value: "AutomnReturn({ type: \"text\", body: \"Plain-text response\" });\n",
-  },
-  {
-    label: "AutomnLog (info)",
-    value: "AutomnLog(\"Starting process\", \"info\");\n",
-  },
-  {
-    label: "AutomnLog (warn)",
-    value: "AutomnLog(\"User not found\", \"warn\");\n",
-  },
-  {
-    label: "AutomnLog (error)",
-    value: "AutomnLog(\"Critical failure\", \"error\");\n",
-  },
-  {
-    label: "AutomnLog (authentication)",
-    value: "AutomnLog(\"Token missing\", \"warn\", { area: \"login\" }, \"authentication\");\n",
-  },
-  {
-    label: "AutomnRunLog",
-    value: "AutomnRunLog(\"Debug info\", { context: \"runner\" });\n",
-  },
-  {
-    label: "AutomnNotify (Admins)",
-    value: "AutomnNotify(\"Admins\", \"Deployment completed\", \"info\");\n",
-  },
+const createSnippetGroup = (groupLabel, options) => ({
+  groupLabel,
+  options,
+});
+
+const NODE_SNIPPET_GROUPS = [
+  createSnippetGroup("AutomnReturn", [
+    {
+      label: "JSON",
+      value: "AutomnReturn({ success: true, data: null });\n",
+    },
+    {
+      label: "Redirect",
+      value: "AutomnReturn({ type: \"redirect\", status: 302, location: \"https://example.com\" });\n",
+    },
+    {
+      label: "Text",
+      value: "AutomnReturn({ type: \"text\", body: \"Plain-text response\" });\n",
+    },
+    {
+      label: "HTML",
+      value: "AutomnReturn({ type: \"html\", body: \"<h1>Hello from Automn</h1>\" });\n",
+    },
+    {
+      label: "Binary download",
+      value: "AutomnReturn({\n  type: \"binary\",\n  headers: {\n    \"Content-Type\": \"application/pdf\",\n  },\n  downloadName: \"report.pdf\",\n  base64: Buffer.from(\"hello world\").toString(\"base64\"),\n});\n",
+    },
+    {
+      label: "Empty",
+      value: "AutomnReturn({ type: \"empty\", status: 204 });\n",
+    },
+  ]),
+  createSnippetGroup("Logging", [
+    {
+      label: "Info log",
+      value: "AutomnLog(\"Starting process\", \"info\");\n",
+    },
+    {
+      label: "Warn log",
+      value: "AutomnLog(\"User not found\", \"warn\");\n",
+    },
+    {
+      label: "Error log",
+      value: "AutomnLog(\"Critical failure\", \"error\");\n",
+    },
+    {
+      label: "Authentication log",
+      value: "AutomnLog(\"Token missing\", \"warn\", { area: \"login\" }, \"authentication\");\n",
+    },
+    {
+      label: "Run log",
+      value: "AutomnRunLog(\"Debug info\", { context: \"runner\" });\n",
+    },
+  ]),
+  createSnippetGroup("Notifications", [
+    {
+      label: "Notify admins",
+      value: "AutomnNotify(\"Admins\", \"Deployment completed\", \"info\");\n",
+    },
+  ]),
 ];
 
-const PYTHON_SNIPPETS = [
-  {
-    label: "AutomnReturn (JSON)",
-    value: "AutomnReturn({\"success\": True, \"data\": None})\n",
-  },
-  {
-    label: "AutomnReturn (redirect)",
-    value: "AutomnReturn({\"type\": \"redirect\", \"status\": 302, \"location\": \"https://example.com\"})\n",
-  },
-  {
-    label: "AutomnReturn (text)",
-    value: "AutomnReturn({\"type\": \"text\", \"body\": \"Plain-text response\"})\n",
-  },
-  {
-    label: "AutomnLog (info)",
-    value: "AutomnLog(\"Starting process\", \"info\")\n",
-  },
-  {
-    label: "AutomnLog (warn)",
-    value: "AutomnLog(\"User not found\", \"warn\")\n",
-  },
-  {
-    label: "AutomnLog (error)",
-    value: "AutomnLog(\"Critical failure\", \"error\")\n",
-  },
-  {
-    label: "AutomnLog (authentication)",
-    value: "AutomnLog(\"Token missing\", \"warn\", {\"area\": \"login\"}, \"authentication\")\n",
-  },
-  {
-    label: "AutomnRunLog",
-    value: "AutomnRunLog(\"Debug info\", {\"context\": \"runner\"})\n",
-  },
-  {
-    label: "AutomnNotify (Admins)",
-    value: "AutomnNotify(\"Admins\", \"Deployment completed\", \"info\")\n",
-  },
+const PYTHON_SNIPPET_GROUPS = [
+  createSnippetGroup("AutomnReturn", [
+    {
+      label: "JSON",
+      value: "AutomnReturn({\"success\": True, \"data\": None})\n",
+    },
+    {
+      label: "Redirect",
+      value: "AutomnReturn({\"type\": \"redirect\", \"status\": 302, \"location\": \"https://example.com\"})\n",
+    },
+    {
+      label: "Text",
+      value: "AutomnReturn({\"type\": \"text\", \"body\": \"Plain-text response\"})\n",
+    },
+    {
+      label: "HTML",
+      value: "AutomnReturn({\"type\": \"html\", \"body\": \"<h1>Hello from Automn</h1>\"})\n",
+    },
+    {
+      label: "Binary download",
+      value: "import base64\nAutomnReturn({\n  \"type\": \"binary\",\n  \"headers\": {\n    \"Content-Type\": \"application/pdf\"\n  },\n  \"downloadName\": \"report.pdf\",\n  \"base64\": base64.b64encode(b\"hello world\").decode(\"utf-8\")\n})\n",
+    },
+    {
+      label: "Empty",
+      value: "AutomnReturn({\"type\": \"empty\", \"status\": 204})\n",
+    },
+  ]),
+  createSnippetGroup("Logging", [
+    {
+      label: "Info log",
+      value: "AutomnLog(\"Starting process\", \"info\")\n",
+    },
+    {
+      label: "Warn log",
+      value: "AutomnLog(\"User not found\", \"warn\")\n",
+    },
+    {
+      label: "Error log",
+      value: "AutomnLog(\"Critical failure\", \"error\")\n",
+    },
+    {
+      label: "Authentication log",
+      value: "AutomnLog(\"Token missing\", \"warn\", {\"area\": \"login\"}, \"authentication\")\n",
+    },
+    {
+      label: "Run log",
+      value: "AutomnRunLog(\"Debug info\", {\"context\": \"runner\"})\n",
+    },
+  ]),
+  createSnippetGroup("Notifications", [
+    {
+      label: "Notify admins",
+      value: "AutomnNotify(\"Admins\", \"Deployment completed\", \"info\")\n",
+    },
+  ]),
 ];
 
-const POWERSHELL_SNIPPETS = [
-  {
-    label: "AutomnReturn (JSON)",
-    value: "AutomnReturn(@{ success = $true; data = $null })\n",
-  },
-  {
-    label: "AutomnReturn (redirect)",
-    value: "AutomnReturn(@{ type = \"redirect\"; status = 302; location = \"https://example.com\" })\n",
-  },
-  {
-    label: "AutomnReturn (text)",
-    value: "AutomnReturn(@{ type = \"text\"; body = \"Plain-text response\" })\n",
-  },
-  {
-    label: "AutomnLog (info)",
-    value: "AutomnLog \"Starting process\" \"info\"\n",
-  },
-  {
-    label: "AutomnLog (warn)",
-    value: "AutomnLog \"User not found\" \"warn\"\n",
-  },
-  {
-    label: "AutomnLog (error)",
-    value: "AutomnLog \"Critical failure\" \"error\"\n",
-  },
-  {
-    label: "AutomnLog (authentication)",
-    value: "AutomnLog \"Token missing\" \"warn\" @{ area = \"login\" } \"authentication\"\n",
-  },
-  {
-    label: "AutomnRunLog",
-    value: "AutomnRunLog \"Debug info\" @{ context = \"runner\" }\n",
-  },
-  {
-    label: "AutomnNotify (Admins)",
-    value: "AutomnNotify \"Admins\" \"Deployment completed\" \"info\"\n",
-  },
+const POWERSHELL_SNIPPET_GROUPS = [
+  createSnippetGroup("AutomnReturn", [
+    {
+      label: "JSON",
+      value: "AutomnReturn(@{ success = $true; data = $null })\n",
+    },
+    {
+      label: "Redirect",
+      value: "AutomnReturn(@{ type = \"redirect\"; status = 302; location = \"https://example.com\" })\n",
+    },
+    {
+      label: "Text",
+      value: "AutomnReturn(@{ type = \"text\"; body = \"Plain-text response\" })\n",
+    },
+    {
+      label: "HTML",
+      value: "AutomnReturn(@{ type = \"html\"; body = \"<h1>Hello from Automn</h1>\" })\n",
+    },
+    {
+      label: "Binary download",
+      value: "$bytes = [System.Text.Encoding]::UTF8.GetBytes(\"hello world\")\n$base64 = [System.Convert]::ToBase64String($bytes)\nAutomnReturn(@{\n  type = \"binary\"\n  headers = @{ \"Content-Type\" = \"application/pdf\" }\n  downloadName = \"report.pdf\"\n  base64 = $base64\n})\n",
+    },
+    {
+      label: "Empty",
+      value: "AutomnReturn(@{ type = \"empty\"; status = 204 })\n",
+    },
+  ]),
+  createSnippetGroup("Logging", [
+    {
+      label: "Info log",
+      value: "AutomnLog \"Starting process\" \"info\"\n",
+    },
+    {
+      label: "Warn log",
+      value: "AutomnLog \"User not found\" \"warn\"\n",
+    },
+    {
+      label: "Error log",
+      value: "AutomnLog \"Critical failure\" \"error\"\n",
+    },
+    {
+      label: "Authentication log",
+      value: "AutomnLog \"Token missing\" \"warn\" @{ area = \"login\" } \"authentication\"\n",
+    },
+    {
+      label: "Run log",
+      value: "AutomnRunLog \"Debug info\" @{ context = \"runner\" }\n",
+    },
+  ]),
+  createSnippetGroup("Notifications", [
+    {
+      label: "Notify admins",
+      value: "AutomnNotify \"Admins\" \"Deployment completed\" \"info\"\n",
+    },
+  ]),
 ];
 
-const SHELL_SNIPPETS = [
-  {
-    label: "AutomnReturn (JSON)",
-    value: "AutomnReturn '{\"success\":true,\"data\":null}'\n",
-  },
-  {
-    label: "AutomnReturn (redirect)",
-    value: "AutomnReturn '{\"type\":\"redirect\",\"status\":302,\"location\":\"https://example.com\"}'\n",
-  },
-  {
-    label: "AutomnReturn (text)",
-    value: "AutomnReturn '{\"type\":\"text\",\"body\":\"Plain-text response\"}'\n",
-  },
-  {
-    label: "AutomnLog (info)",
-    value: "AutomnLog \"Starting process\" \"info\"\n",
-  },
-  {
-    label: "AutomnLog (warn)",
-    value: "AutomnLog \"User not found\" \"warn\"\n",
-  },
-  {
-    label: "AutomnLog (error)",
-    value: "AutomnLog \"Critical failure\" \"error\"\n",
-  },
-  {
-    label: "AutomnLog (authentication)",
-    value: "AutomnLog \"Token missing\" \"warn\" '{\"area\":\"login\"}' \"authentication\"\n",
-  },
-  {
-    label: "AutomnRunLog",
-    value: "AutomnRunLog \"Debug info\"\n",
-  },
-  {
-    label: "AutomnNotify (Admins)",
-    value: "AutomnNotify \"Admins\" \"Deployment completed\" \"info\"\n",
-  },
+const SHELL_SNIPPET_GROUPS = [
+  createSnippetGroup("AutomnReturn", [
+    {
+      label: "JSON",
+      value: "AutomnReturn '{\"success\":true,\"data\":null}'\n",
+    },
+    {
+      label: "Redirect",
+      value: "AutomnReturn '{\"type\":\"redirect\",\"status\":302,\"location\":\"https://example.com\"}'\n",
+    },
+    {
+      label: "Text",
+      value: "AutomnReturn '{\"type\":\"text\",\"body\":\"Plain-text response\"}'\n",
+    },
+    {
+      label: "HTML",
+      value: "AutomnReturn '{\"type\":\"html\",\"body\":\"<h1>Hello from Automn</h1>\"}'\n",
+    },
+    {
+      label: "Binary download",
+      value: "base64_payload=$(printf 'hello world' | base64 | tr -d '\\n')\nAutomnReturn \"{\\\"type\\\":\\\"binary\\\",\\\"headers\\\":{\\\"Content-Type\\\":\\\"application/pdf\\\"},\\\"downloadName\\\":\\\"report.pdf\\\",\\\"base64\\\":\\\"${base64_payload}\\\"}\"\n",
+    },
+    {
+      label: "Empty",
+      value: "AutomnReturn '{\"type\":\"empty\",\"status\":204}'\n",
+    },
+  ]),
+  createSnippetGroup("Logging", [
+    {
+      label: "Info log",
+      value: "AutomnLog \"Starting process\" \"info\"\n",
+    },
+    {
+      label: "Warn log",
+      value: "AutomnLog \"User not found\" \"warn\"\n",
+    },
+    {
+      label: "Error log",
+      value: "AutomnLog \"Critical failure\" \"error\"\n",
+    },
+    {
+      label: "Authentication log",
+      value: "AutomnLog \"Token missing\" \"warn\" '{\"area\":\"login\"}' \"authentication\"\n",
+    },
+    {
+      label: "Run log",
+      value: "AutomnRunLog \"Debug info\"\n",
+    },
+  ]),
+  createSnippetGroup("Notifications", [
+    {
+      label: "Notify admins",
+      value: "AutomnNotify \"Admins\" \"Deployment completed\" \"info\"\n",
+    },
+  ]),
 ];
 
 const SNIPPETS = {
-  node: NODE_SNIPPETS,
-  javascript: NODE_SNIPPETS,
-  typescript: NODE_SNIPPETS,
-  python: PYTHON_SNIPPETS,
-  powershell: POWERSHELL_SNIPPETS,
-  shell: SHELL_SNIPPETS,
+  node: NODE_SNIPPET_GROUPS,
+  javascript: NODE_SNIPPET_GROUPS,
+  typescript: NODE_SNIPPET_GROUPS,
+  python: PYTHON_SNIPPET_GROUPS,
+  powershell: POWERSHELL_SNIPPET_GROUPS,
+  shell: SHELL_SNIPPET_GROUPS,
 };
 
 const VARIABLE_WARNING_STORAGE_KEY = "automn.hideVariableSecurityWarning";
@@ -615,7 +692,7 @@ export default function ScriptEditor({
     editorRef.current.focus();
   }, [language, isActive]);
 
-  const snippetOptions = useMemo(() => SNIPPETS[language] || [], [language]);
+  const snippetGroups = useMemo(() => SNIPPETS[language] || [], [language]);
   const variableOptions = useMemo(() => {
     if (!variables) return [];
     const groups = [
@@ -1049,7 +1126,7 @@ export default function ScriptEditor({
                 ))}
               </select>
             )}
-            {snippetOptions.length > 0 && (
+            {snippetGroups.length > 0 && (
               <select
                 onChange={handleSnippetInsert}
                 className="bg-slate-900 border border-slate-600 rounded px-2 py-1 text-xs text-slate-200"
@@ -1058,10 +1135,17 @@ export default function ScriptEditor({
                 <option value="" disabled>
                   Insert snippet…
                 </option>
-                {snippetOptions.map((option) => (
-                  <option key={option.label} value={option.value}>
-                    {option.label}
-                  </option>
+                {snippetGroups.map((group) => (
+                  <optgroup key={group.groupLabel} label={group.groupLabel}>
+                    {group.options.map((option) => (
+                      <option
+                        key={`${group.groupLabel}-${option.label}`}
+                        value={option.value}
+                      >
+                        {group.groupLabel} › {option.label}
+                      </option>
+                    ))}
+                  </optgroup>
                 ))}
               </select>
             )}

--- a/frontend/src/components/ScriptEditor.jsx
+++ b/frontend/src/components/ScriptEditor.jsx
@@ -4,8 +4,16 @@ import { apiRequest } from "../utils/api";
 
 const NODE_SNIPPETS = [
   {
-    label: "AutomnReturn (success)",
+    label: "AutomnReturn (JSON)",
     value: "AutomnReturn({ success: true, data: null });\n",
+  },
+  {
+    label: "AutomnReturn (redirect)",
+    value: "AutomnReturn({ type: \"redirect\", status: 302, location: \"https://example.com\" });\n",
+  },
+  {
+    label: "AutomnReturn (text)",
+    value: "AutomnReturn({ type: \"text\", body: \"Plain-text response\" });\n",
   },
   {
     label: "AutomnLog (info)",
@@ -35,8 +43,16 @@ const NODE_SNIPPETS = [
 
 const PYTHON_SNIPPETS = [
   {
-    label: "AutomnReturn (success)",
+    label: "AutomnReturn (JSON)",
     value: "AutomnReturn({\"success\": True, \"data\": None})\n",
+  },
+  {
+    label: "AutomnReturn (redirect)",
+    value: "AutomnReturn({\"type\": \"redirect\", \"status\": 302, \"location\": \"https://example.com\"})\n",
+  },
+  {
+    label: "AutomnReturn (text)",
+    value: "AutomnReturn({\"type\": \"text\", \"body\": \"Plain-text response\"})\n",
   },
   {
     label: "AutomnLog (info)",
@@ -66,8 +82,16 @@ const PYTHON_SNIPPETS = [
 
 const POWERSHELL_SNIPPETS = [
   {
-    label: "AutomnReturn (success)",
+    label: "AutomnReturn (JSON)",
     value: "AutomnReturn(@{ success = $true; data = $null })\n",
+  },
+  {
+    label: "AutomnReturn (redirect)",
+    value: "AutomnReturn(@{ type = \"redirect\"; status = 302; location = \"https://example.com\" })\n",
+  },
+  {
+    label: "AutomnReturn (text)",
+    value: "AutomnReturn(@{ type = \"text\"; body = \"Plain-text response\" })\n",
   },
   {
     label: "AutomnLog (info)",
@@ -97,8 +121,16 @@ const POWERSHELL_SNIPPETS = [
 
 const SHELL_SNIPPETS = [
   {
-    label: "AutomnReturn (success)",
+    label: "AutomnReturn (JSON)",
     value: "AutomnReturn '{\"success\":true,\"data\":null}'\n",
+  },
+  {
+    label: "AutomnReturn (redirect)",
+    value: "AutomnReturn '{\"type\":\"redirect\",\"status\":302,\"location\":\"https://example.com\"}'\n",
+  },
+  {
+    label: "AutomnReturn (text)",
+    value: "AutomnReturn '{\"type\":\"text\",\"body\":\"Plain-text response\"}'\n",
   },
   {
     label: "AutomnLog (info)",

--- a/server.js
+++ b/server.js
@@ -935,6 +935,176 @@ async function resolveRequestPayload(req) {
   return text;
 }
 
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+const AUTOMN_HTTP_RESPONSE_TYPES = new Set(["json", "text", "html", "redirect", "binary", "empty"]);
+const AUTOMN_BLOCKED_RESPONSE_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "date",
+  "keep-alive",
+  "transfer-encoding",
+]);
+
+function normalizeAutomnResponseHeaders(headers) {
+  if (!isPlainObject(headers)) {
+    return {};
+  }
+
+  const normalized = {};
+  for (const [rawKey, rawValue] of Object.entries(headers)) {
+    const key = typeof rawKey === "string" ? rawKey.trim() : "";
+    if (!key) continue;
+
+    const lowerKey = key.toLowerCase();
+    if (AUTOMN_BLOCKED_RESPONSE_HEADERS.has(lowerKey)) {
+      continue;
+    }
+
+    if (rawValue === undefined || rawValue === null) {
+      continue;
+    }
+
+    normalized[key] = Array.isArray(rawValue)
+      ? rawValue.map((value) => String(value))
+      : String(rawValue);
+  }
+
+  return normalized;
+}
+
+function normalizeAutomnHttpResponseDescriptor(value) {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+
+  const type = typeof value.type === "string" ? value.type.trim().toLowerCase() : "";
+  if (!AUTOMN_HTTP_RESPONSE_TYPES.has(type)) {
+    return null;
+  }
+
+  const numericStatus = Number.parseInt(value.status, 10);
+  const status = Number.isInteger(numericStatus) && numericStatus >= 100 && numericStatus <= 999
+    ? numericStatus
+    : type === "redirect"
+      ? 302
+      : type === "empty"
+        ? 204
+        : 200;
+  const headers = normalizeAutomnResponseHeaders(value.headers);
+
+  if (type === "redirect") {
+    const location = typeof value.location === "string" && value.location.trim()
+      ? value.location.trim()
+      : typeof value.url === "string" && value.url.trim()
+        ? value.url.trim()
+        : "";
+    if (!location) {
+      return {
+        invalid: true,
+        message: "AutomnReturn redirect responses require a non-empty location",
+      };
+    }
+    return { type, status, headers, location };
+  }
+
+  if (type === "binary") {
+    const base64 = typeof value.base64 === "string" ? value.base64.trim() : "";
+    if (!base64) {
+      return {
+        invalid: true,
+        message: "AutomnReturn binary responses require a base64 payload",
+      };
+    }
+
+    let body;
+    try {
+      body = Buffer.from(base64, "base64");
+    } catch (err) {
+      return {
+        invalid: true,
+        message: `AutomnReturn binary payload could not be decoded: ${err.message}`,
+      };
+    }
+
+    if (!headers["Content-Type"] && !headers["content-type"]) {
+      headers["Content-Type"] = "application/octet-stream";
+    }
+    if (typeof value.downloadName === "string" && value.downloadName.trim()) {
+      headers["Content-Disposition"] = `attachment; filename="${value.downloadName.trim().replace(/"/g, "")}"`;
+    }
+
+    return { type, status, headers, body };
+  }
+
+  if (type === "empty") {
+    return { type, status, headers, body: "" };
+  }
+
+  const body = Object.prototype.hasOwnProperty.call(value, "body") ? value.body : null;
+
+  if (type === "json") {
+    return { type, status, headers, body };
+  }
+
+  const normalizedBody = body === null || body === undefined
+    ? ""
+    : typeof body === "string"
+      ? body
+      : String(body);
+
+  if (type === "html" && !headers["Content-Type"] && !headers["content-type"]) {
+    headers["Content-Type"] = "text/html; charset=utf-8";
+  }
+  if (type === "text" && !headers["Content-Type"] && !headers["content-type"]) {
+    headers["Content-Type"] = "text/plain; charset=utf-8";
+  }
+
+  return { type, status, headers, body: normalizedBody };
+}
+
+function sendAutomnHttpResponse(res, descriptor, runId = null) {
+  if (!descriptor || descriptor.invalid) {
+    return false;
+  }
+
+  res.status(descriptor.status || 200);
+
+  if (runId) {
+    res.set("X-Automn-Run-Id", runId);
+  }
+
+  for (const [key, value] of Object.entries(descriptor.headers || {})) {
+    res.set(key, value);
+  }
+
+  if (descriptor.type === "redirect") {
+    res.set("Location", descriptor.location);
+    res.send();
+    return true;
+  }
+
+  if (descriptor.type === "json") {
+    res.json(descriptor.body);
+    return true;
+  }
+
+  if (descriptor.type === "binary") {
+    res.send(descriptor.body);
+    return true;
+  }
+
+  if (descriptor.type === "empty") {
+    res.send();
+    return true;
+  }
+
+  res.send(descriptor.body);
+  return true;
+}
+
 function safeSerializeInput(value) {
   try {
     return JSON.stringify(value ?? {});
@@ -5698,6 +5868,24 @@ function registerScriptRoute(script) {
       await persistScriptNotifications(latest, result);
       const statusCode = result.code === 0 ? 200 : 500;
       const includeMetadata = shouldIncludeMetadata();
+      const resolvedRunId = result.runId || runId;
+      const automnHttpResponse = result.code === 0
+        ? normalizeAutomnHttpResponseDescriptor(result.returnData)
+        : null;
+
+      if (automnHttpResponse?.invalid) {
+        res.status(500).json(attachRunId(buildErrorPayload(automnHttpResponse.message), resolvedRunId));
+        return;
+      }
+
+      if (automnHttpResponse) {
+        sendAutomnHttpResponse(
+          res,
+          automnHttpResponse,
+          shouldIncludeRunId() ? resolvedRunId : null,
+        );
+        return;
+      }
 
       if (includeMetadata) {
         const metadataPayload = {
@@ -5710,7 +5898,6 @@ function registerScriptRoute(script) {
           input: result.input ?? input,
           durationMs: Date.now() - start,
         };
-        const resolvedRunId = result.runId || runId;
         if (shouldIncludeRunId() && resolvedRunId) {
           metadataPayload.runId = resolvedRunId;
         }
@@ -5721,7 +5908,6 @@ function registerScriptRoute(script) {
       if (result.code === 0) {
         const minimalPayload = { return: result.returnData };
         if (shouldIncludeRunId()) {
-          const resolvedRunId = result.runId || runId;
           if (resolvedRunId) {
             minimalPayload.runId = resolvedRunId;
           }

--- a/server.js
+++ b/server.js
@@ -980,6 +980,13 @@ function normalizeAutomnHttpResponseDescriptor(value) {
     return null;
   }
 
+  if (Object.prototype.hasOwnProperty.call(value, "return")) {
+    const nestedDescriptor = normalizeAutomnHttpResponseDescriptor(value.return);
+    if (nestedDescriptor) {
+      return nestedDescriptor;
+    }
+  }
+
   const type = typeof value.type === "string" ? value.type.trim().toLowerCase() : "";
   if (!AUTOMN_HTTP_RESPONSE_TYPES.has(type)) {
     return null;


### PR DESCRIPTION
### Motivation
- Allow scripts invoked via `/s/<endpoint>` to control the full HTTP response (redirects, text/html bodies, binary downloads, empty responses) instead of always being wrapped in the default JSON envelope.
- Provide safe validation and sanitization of script-provided response descriptors to avoid header injection and malformed responses.

### Description
- Implemented normalization/validation utilities in `server.js`: `isPlainObject`, `normalizeAutomnResponseHeaders`, and `normalizeAutomnHttpResponseDescriptor` to validate descriptors and block unsafe headers.
- Added `sendAutomnHttpResponse` to emit typed responses and integrated descriptor handling into the script route so successful runs can return `json`, `text`, `html`, `redirect`, `binary`, or `empty` responses and optionally include `X-Automn-Run-Id`.
- Binary responses accept base64 payloads and will set `Content-Type` and `Content-Disposition` (via `downloadName`) when appropriate, and redirect descriptors require a non-empty `location`.
- Updated documentation (`README.md`, `docs/runner.md`) and the editor UI (`frontend/src/components/ScriptEditor.jsx`) with examples and snippets for the new `AutomnReturn` response types and renamed the default snippet to `AutomnReturn (JSON)`.

### Testing
- Ran the project lint and test commands (`npm run lint`, `npm test`) and the front-end build (`npm run build`); these completed without errors.
- Exercised example `/s/<endpoint>` flows locally using `AutomnReturn` descriptors for `json`, `text`, `redirect`, and `binary`, and observed correct HTTP status, headers, and bodies being returned.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba1e3e7ba083269c4f544aa0b0e762)