### PR TITLE
Add persistent runner apt package management

### DIFF
--- a/db.js
+++ b/db.js
@@ -1156,6 +1156,9 @@ function initializeSchema(database) {
       runner_uptime INTEGER,
       runner_runtimes TEXT,
       minimum_host_version TEXT,
+      package_manager TEXT,
+      desired_packages TEXT,
+      installed_packages TEXT,
       admin_only INTEGER DEFAULT 0,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
@@ -1193,6 +1196,9 @@ function initializeSchema(database) {
       ensureColumn("runner_uptime", "INTEGER");
       ensureColumn("runner_runtimes", "TEXT");
       ensureColumn("minimum_host_version", "TEXT");
+      ensureColumn("package_manager", "TEXT");
+      ensureColumn("desired_packages", "TEXT");
+      ensureColumn("installed_packages", "TEXT");
       ensureColumn("admin_only", "INTEGER DEFAULT 0");
       ensureColumn("created_at", "TEXT DEFAULT CURRENT_TIMESTAMP");
       ensureColumn("updated_at", "TEXT DEFAULT CURRENT_TIMESTAMP");
@@ -1352,6 +1358,134 @@ function serializeRunnerRuntimes(value) {
   }
 }
 
+function parseRunnerPackageList(value) {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean);
+  }
+  if (typeof value !== "string") {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean);
+  } catch (err) {
+    return [];
+  }
+}
+
+function serializeRunnerPackageList(value) {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const normalized = Array.from(
+    new Set(
+      value
+        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+        .filter(Boolean),
+    ),
+  );
+  try {
+    return JSON.stringify(normalized);
+  } catch (err) {
+    return null;
+  }
+}
+
+function parseRunnerInstalledPackages(value) {
+  if (!value) {
+    return [];
+  }
+  const source = typeof value === "string" ? value : JSON.stringify(value);
+  if (!source) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(source);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((entry) => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          return null;
+        }
+        const name = typeof entry.name === "string" ? entry.name.trim() : "";
+        if (!name) {
+          return null;
+        }
+        const version = typeof entry.version === "string" ? entry.version.trim() : null;
+        const summary = typeof entry.summary === "string" ? entry.summary.trim() : null;
+        const pathValue = typeof entry.path === "string" ? entry.path.trim() : null;
+        const paths = Array.isArray(entry.paths)
+          ? entry.paths
+              .map((item) => (typeof item === "string" ? item.trim() : ""))
+              .filter(Boolean)
+          : [];
+        return {
+          name,
+          version: version || null,
+          summary: summary || null,
+          path: pathValue || (paths[0] || null),
+          paths,
+        };
+      })
+      .filter(Boolean);
+  } catch (err) {
+    return [];
+  }
+}
+
+function serializeRunnerInstalledPackages(value) {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const normalized = value
+    .map((entry) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return null;
+      }
+      const name = typeof entry.name === "string" ? entry.name.trim() : "";
+      if (!name) {
+        return null;
+      }
+      const paths = Array.isArray(entry.paths)
+        ? Array.from(
+            new Set(
+              entry.paths
+                .map((item) => (typeof item === "string" ? item.trim() : ""))
+                .filter(Boolean),
+            ),
+          )
+        : [];
+      const pathValue = typeof entry.path === "string" ? entry.path.trim() : "";
+      const summary = typeof entry.summary === "string" ? entry.summary.trim() : "";
+      const version = typeof entry.version === "string" ? entry.version.trim() : "";
+      return {
+        name,
+        version: version || null,
+        summary: summary || null,
+        path: pathValue || (paths[0] || null),
+        paths,
+      };
+    })
+    .filter(Boolean);
+  try {
+    return JSON.stringify(normalized);
+  } catch (err) {
+    return null;
+  }
+}
+
 function mapRunnerHostRow(row, { includeSecret = false } = {}) {
   if (!row) return null;
   const mapped = {
@@ -1379,6 +1513,9 @@ function mapRunnerHostRow(row, { includeSecret = false } = {}) {
         : Number(row.runner_uptime),
     runnerRuntimes: parseRunnerRuntimes(row.runner_runtimes),
     minimumHostVersion: row.minimum_host_version || null,
+    packageManager: row.package_manager || null,
+    desiredPackages: parseRunnerPackageList(row.desired_packages),
+    installedPackages: parseRunnerInstalledPackages(row.installed_packages),
     adminOnly: normalizeDbBoolean(row.admin_only),
     createdAt: row.created_at || null,
     updatedAt: row.updated_at || null,
@@ -1400,7 +1537,7 @@ function getRunnerHostById(database, id, { includeSecret = false } = {}) {
     }
 
     database.get(
-      `SELECT id, name, secret_hash, status, status_message, endpoint, last_seen_at, max_concurrency, timeout_ms, runner_version, runner_os, runner_platform, runner_arch, runner_uptime, runner_runtimes, minimum_host_version, admin_only, created_at, updated_at, disabled_at
+      `SELECT id, name, secret_hash, status, status_message, endpoint, last_seen_at, max_concurrency, timeout_ms, runner_version, runner_os, runner_platform, runner_arch, runner_uptime, runner_runtimes, minimum_host_version, package_manager, desired_packages, installed_packages, admin_only, created_at, updated_at, disabled_at
          FROM runner_hosts
         WHERE id=?`,
       [id],
@@ -1418,7 +1555,7 @@ function getRunnerHostById(database, id, { includeSecret = false } = {}) {
 function listRunnerHosts(database) {
   return new Promise((resolve, reject) => {
     database.all(
-      `SELECT id, name, status, status_message, endpoint, last_seen_at, max_concurrency, timeout_ms, runner_version, runner_os, runner_platform, runner_arch, runner_uptime, runner_runtimes, minimum_host_version, admin_only, created_at, updated_at, disabled_at
+      `SELECT id, name, status, status_message, endpoint, last_seen_at, max_concurrency, timeout_ms, runner_version, runner_os, runner_platform, runner_arch, runner_uptime, runner_runtimes, minimum_host_version, package_manager, desired_packages, installed_packages, admin_only, created_at, updated_at, disabled_at
          FROM runner_hosts
         ORDER BY name COLLATE NOCASE ASC`,
       [],
@@ -1545,6 +1682,21 @@ function updateRunnerHostStatus(database, id, updates = {}) {
   if (Object.prototype.hasOwnProperty.call(updates, "minimumHostVersion")) {
     fields.push("minimum_host_version=?");
     values.push(updates.minimumHostVersion || null);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, "packageManager")) {
+    fields.push("package_manager=?");
+    values.push(updates.packageManager || null);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, "desiredPackages")) {
+    fields.push("desired_packages=?");
+    values.push(serializeRunnerPackageList(updates.desiredPackages));
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, "installedPackages")) {
+    fields.push("installed_packages=?");
+    values.push(serializeRunnerInstalledPackages(updates.installedPackages));
   }
 
   if (Object.prototype.hasOwnProperty.call(updates, "adminOnly")) {

--- a/frontend/src/components/SettingsRunnerHosts.jsx
+++ b/frontend/src/components/SettingsRunnerHosts.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
+import { apiRequest } from "../utils/api";
+import { useNotificationDialog } from "./NotificationDialogProvider";
 
 const RUNNER_RECOMMENDED_PACKAGES = [
   "chromium",
@@ -15,8 +17,6 @@ const RUNNER_RECOMMENDED_PACKAGES = [
   "postgresql-client",
   "openssh-client",
 ];
-import { apiRequest } from "../utils/api";
-import { useNotificationDialog } from "./NotificationDialogProvider";
 
 const initialFormState = {
   id: "",
@@ -829,7 +829,7 @@ export default function SettingsRunnerHosts({ onAuthError }) {
   return (
     <div className="space-y-6">
       {!isCreateOpen && (
-        <div className="flex justify-end">
+        <div className="relative z-10 flex justify-end">
           <button
             type="button"
             onClick={() => {

--- a/frontend/src/components/SettingsRunnerHosts.jsx
+++ b/frontend/src/components/SettingsRunnerHosts.jsx
@@ -1,4 +1,20 @@
 import { useEffect, useMemo, useState } from "react";
+
+const RUNNER_RECOMMENDED_PACKAGES = [
+  "chromium",
+  "curl",
+  "wget",
+  "git",
+  "zip",
+  "unzip",
+  "jq",
+  "ffmpeg",
+  "poppler-utils",
+  "default-mysql-client",
+  "sqlite3",
+  "postgresql-client",
+  "openssh-client",
+];
 import { apiRequest } from "../utils/api";
 import { useNotificationDialog } from "./NotificationDialogProvider";
 
@@ -262,6 +278,7 @@ export default function SettingsRunnerHosts({ onAuthError }) {
   const [hostNotices, setHostNotices] = useState({});
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [expandedHosts, setExpandedHosts] = useState({});
+  const [packagePanels, setPackagePanels] = useState({});
 
   const expandHost = (hostId) => {
     if (!hostId) return;
@@ -273,6 +290,7 @@ export default function SettingsRunnerHosts({ onAuthError }) {
 
   const toggleHostExpansion = (hostId) => {
     if (!hostId) return;
+    const shouldOpen = !expandedHosts[hostId];
     setExpandedHosts((prev) => {
       const next = { ...prev };
       if (next[hostId]) {
@@ -282,6 +300,9 @@ export default function SettingsRunnerHosts({ onAuthError }) {
       }
       return next;
     });
+    if (shouldOpen) {
+      loadRunnerPackageDetails(hostId).catch(() => {});
+    }
   };
 
   const sortedHosts = useMemo(() => {
@@ -296,6 +317,111 @@ export default function SettingsRunnerHosts({ onAuthError }) {
       next.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
       return next;
     });
+  };
+
+  const updatePackagePanel = (hostId, updates) => {
+    if (!hostId) return;
+    setPackagePanels((prev) => ({
+      ...prev,
+      [hostId]: {
+        ...(prev[hostId] || {
+          query: "",
+          results: [],
+          isSearching: false,
+          isInstalling: false,
+          error: "",
+          lastLoadedAt: 0,
+        }),
+        ...updates,
+      },
+    }));
+  };
+
+  const loadRunnerPackageDetails = async (hostId, { force = false } = {}) => {
+    if (!hostId) return;
+    const currentPanel = packagePanels[hostId];
+    if (!force && currentPanel?.lastLoadedAt) {
+      return;
+    }
+    updatePackagePanel(hostId, { error: "" });
+    try {
+      const response = await apiRequest(`/api/settings/runner-hosts/${hostId}/system-packages`);
+      const updatedHost = response?.runnerHost;
+      if (updatedHost) {
+        updateHostList(updatedHost);
+      } else {
+        updateHostList({
+          ...(hosts.find((entry) => entry.id === hostId) || { id: hostId }),
+          packageManager: response?.packageManager || null,
+          desiredPackages: Array.isArray(response?.desiredPackages) ? response.desiredPackages : [],
+          installedPackages: Array.isArray(response?.installedPackages) ? response.installedPackages : [],
+        });
+      }
+      updatePackagePanel(hostId, { lastLoadedAt: Date.now() });
+    } catch (err) {
+      updatePackagePanel(hostId, {
+        error: err?.data?.error || err.message || "Failed to load system packages.",
+      });
+    }
+  };
+
+  const handlePackageSearchChange = (hostId, value) => {
+    updatePackagePanel(hostId, { query: value, error: "" });
+  };
+
+  const handlePackageSearch = async (hostId) => {
+    const query = packagePanels[hostId]?.query?.trim() || "";
+    if (!query) {
+      updatePackagePanel(hostId, { results: [], error: "Enter a package name to search." });
+      return;
+    }
+    updatePackagePanel(hostId, { isSearching: true, error: "" });
+    try {
+      const response = await apiRequest(`/api/settings/runner-hosts/${hostId}/system-packages/search?q=${encodeURIComponent(query)}`);
+      updatePackagePanel(hostId, { results: Array.isArray(response?.results) ? response.results : [] });
+    } catch (err) {
+      updatePackagePanel(hostId, {
+        error: err?.data?.error || err.message || "Failed to search packages.",
+      });
+    } finally {
+      updatePackagePanel(hostId, { isSearching: false });
+    }
+  };
+
+  const handleInstallPackages = async (host, packageNames) => {
+    if (!host?.id) return;
+    const packages = Array.from(new Set((Array.isArray(packageNames) ? packageNames : [])
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean)));
+    if (!packages.length) {
+      updatePackagePanel(host.id, { error: "Select at least one package to install." });
+      return;
+    }
+    updatePackagePanel(host.id, { isInstalling: true, error: "" });
+    try {
+      const response = await apiRequest(`/api/settings/runner-hosts/${host.id}/system-packages/install`, {
+        method: "POST",
+        body: { packages },
+      });
+      if (response?.runnerHost) {
+        updateHostList(response.runnerHost);
+      }
+      setHostNotice(host.id, {
+        type: "success",
+        message: `Installed packages: ${packages.join(", ")}.`,
+      });
+      updatePackagePanel(host.id, {
+        results: [],
+        query: "",
+        lastLoadedAt: Date.now(),
+      });
+    } catch (err) {
+      updatePackagePanel(host.id, {
+        error: err?.data?.error || err.message || "Failed to install packages.",
+      });
+    } finally {
+      updatePackagePanel(host.id, { isInstalling: false });
+    }
   };
 
   const setHostNotice = (hostId, notice) => {
@@ -880,6 +1006,9 @@ export default function SettingsRunnerHosts({ onAuthError }) {
               );
               const { icon: osIcon, label: osLabel } = getOsIndicator(host);
               const isExpanded = Boolean(expandedHosts[host.id]);
+              const packagePanel = packagePanels[host.id] || {};
+              const installedPackages = Array.isArray(host.installedPackages) ? host.installedPackages : [];
+              const desiredPackages = Array.isArray(host.desiredPackages) ? host.desiredPackages : [];
 
               return (
                 <div
@@ -1169,6 +1298,127 @@ export default function SettingsRunnerHosts({ onAuthError }) {
                             </div>
                           </div>
                         </div>
+                        <div className="md:col-span-2 lg:col-span-3">
+                          <span className="text-xs uppercase text-slate-500">Additional applications</span>
+                          <div className="mt-2 rounded-md border border-slate-800/80 bg-slate-950/40 p-3">
+                            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                              <div>
+                                <div className="text-sm font-medium text-slate-200">
+                                  Package manager: {host.packageManager || "Unavailable"}
+                                </div>
+                                <div className="mt-1 text-xs text-slate-500">
+                                  Installed packages are persisted in runner state and re-applied when the runner starts.
+                                </div>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                {RUNNER_RECOMMENDED_PACKAGES.map((pkg) => (
+                                  <button
+                                    key={pkg}
+                                    type="button"
+                                    onClick={() => handleInstallPackages(host, [pkg])}
+                                    disabled={packagePanel.isInstalling || host.packageManager !== "apt"}
+                                    className="rounded border border-slate-700 px-2.5 py-1 text-xs font-semibold text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+                                  >
+                                    + {pkg}
+                                  </button>
+                                ))}
+                              </div>
+                            </div>
+                            <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+                              <input
+                                type="text"
+                                value={packagePanel.query || ""}
+                                onChange={(event) => handlePackageSearchChange(host.id, event.target.value)}
+                                placeholder="Search apt packages"
+                                className="flex-1 rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-slate-500 focus:outline-none"
+                              />
+                              <button
+                                type="button"
+                                onClick={() => handlePackageSearch(host.id)}
+                                disabled={packagePanel.isSearching || host.packageManager !== "apt"}
+                                className="button-clear rounded border px-3 py-2 text-xs font-semibold uppercase tracking-wide transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                {packagePanel.isSearching ? "Searching..." : "Search apt"}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => loadRunnerPackageDetails(host.id, { force: true })}
+                                className="button-clear rounded border px-3 py-2 text-xs font-semibold uppercase tracking-wide transition-colors"
+                              >
+                                Refresh apps
+                              </button>
+                            </div>
+                            {packagePanel.error && (
+                              <div className="mt-3 text-sm text-rose-400">{packagePanel.error}</div>
+                            )}
+                            {desiredPackages.length > 0 && (
+                              <div className="mt-4">
+                                <div className="text-xs uppercase text-slate-500">Persisted packages</div>
+                                <div className="mt-2 flex flex-wrap gap-2">
+                                  {desiredPackages.map((pkg) => (
+                                    <span key={pkg} className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-200">
+                                      {pkg}
+                                    </span>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+                            {Array.isArray(packagePanel.results) && packagePanel.results.length > 0 && (
+                              <div className="mt-4">
+                                <div className="text-xs uppercase text-slate-500">Search results</div>
+                                <div className="mt-2 space-y-2">
+                                  {packagePanel.results.map((pkg) => (
+                                    <div key={pkg.name} className="flex flex-col gap-2 rounded border border-slate-800/70 bg-slate-900/60 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+                                      <div>
+                                        <div className="font-mono text-sm text-slate-100">{pkg.name}</div>
+                                        <div className="text-xs text-slate-400">{pkg.summary || "No description available."}</div>
+                                      </div>
+                                      <button
+                                        type="button"
+                                        onClick={() => handleInstallPackages(host, [pkg.name])}
+                                        disabled={packagePanel.isInstalling}
+                                        className="button-run rounded border px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+                                      >
+                                        {packagePanel.isInstalling ? "Installing..." : "Install"}
+                                      </button>
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+                            <div className="mt-4">
+                              <div className="text-xs uppercase text-slate-500">Installed applications</div>
+                              {installedPackages.length > 0 ? (
+                                <div className="mt-2 overflow-x-auto">
+                                  <table className="min-w-full text-left text-sm text-slate-300">
+                                    <thead>
+                                      <tr className="text-xs uppercase text-slate-500">
+                                        <th className="pb-2 pr-4 font-medium">Package</th>
+                                        <th className="pb-2 pr-4 font-medium">Version</th>
+                                        <th className="pb-2 pr-4 font-medium">Path</th>
+                                      </tr>
+                                    </thead>
+                                    <tbody>
+                                      {installedPackages.map((pkg) => (
+                                        <tr key={pkg.name} className="border-t border-slate-800/60 align-top">
+                                          <td className="py-2 pr-4">
+                                            <div className="font-mono text-slate-100">{pkg.name}</div>
+                                            {pkg.summary && <div className="text-xs text-slate-500">{pkg.summary}</div>}
+                                          </td>
+                                          <td className="py-2 pr-4 font-mono text-xs text-slate-200">{pkg.version || "—"}</td>
+                                          <td className="py-2 pr-4 font-mono text-xs text-slate-400">{pkg.path || "—"}</td>
+                                        </tr>
+                                      ))}
+                                    </tbody>
+                                  </table>
+                                </div>
+                              ) : (
+                                <div className="mt-1 text-slate-400">No persisted applications reported yet.</div>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+
                         <div className="md:col-span-2 lg:col-span-3">
                           <span className="text-xs uppercase text-slate-500">Runtime versions</span>
                           {runtimeEntries.length > 0 ? (

--- a/runner/service.js
+++ b/runner/service.js
@@ -5,7 +5,7 @@ const path = require("path");
 const fs = require("fs");
 const os = require("os");
 const crypto = require("crypto");
-const { execFile } = require("child_process");
+const { execFile, spawn } = require("child_process");
 const {
   executeScript,
   LOG_MARKER,
@@ -32,6 +32,21 @@ const DEFAULT_HEARTBEAT_INTERVAL = 60_000;
 const MIN_SECRET_LENGTH = 12;
 const RUNNER_VERSION = "0.2.16";
 const MINIMUM_HOST_VERSION = "0.2.15";
+const RECOMMENDED_SYSTEM_PACKAGES = Object.freeze([
+  "chromium",
+  "curl",
+  "wget",
+  "git",
+  "zip",
+  "unzip",
+  "jq",
+  "ffmpeg",
+  "poppler-utils",
+  "default-mysql-client",
+  "sqlite3",
+  "postgresql-client",
+  "openssh-client",
+]);
 
 const runtimeExecutableEnv = {
   node: normalizeExecutableValue(process.env.AUTOMN_RUNNER_NODE_PATH || ""),
@@ -279,6 +294,275 @@ function parseInteger(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function execFileAsync(command, args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, options, (error, stdout, stderr) => {
+      if (error) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        reject(error);
+        return;
+      }
+      resolve({ stdout: stdout || "", stderr: stderr || "" });
+    });
+  });
+}
+
+function normalizePackageName(value) {
+  if (!value || typeof value !== "string") {
+    return "";
+  }
+  const normalized = value.trim().toLowerCase();
+  return /^[a-z0-9][a-z0-9+.-]*$/.test(normalized) ? normalized : "";
+}
+
+function normalizePackageList(input) {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      input
+        .map((value) => normalizePackageName(typeof value === "string" ? value : ""))
+        .filter(Boolean),
+    ),
+  );
+}
+
+function detectPackageManager() {
+  if (process.platform !== "linux") {
+    return null;
+  }
+  if (fs.existsSync("/usr/bin/apt-get") || fs.existsSync("/bin/apt-get")) {
+    return "apt";
+  }
+  return null;
+}
+
+function parseInstalledPackages(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return null;
+      }
+      const name = normalizePackageName(typeof entry.name === "string" ? entry.name : "");
+      if (!name) {
+        return null;
+      }
+      const paths = Array.isArray(entry.paths)
+        ? Array.from(
+            new Set(
+              entry.paths
+                .map((item) => (typeof item === "string" ? item.trim() : ""))
+                .filter(Boolean),
+            ),
+          )
+        : [];
+      return {
+        name,
+        version: typeof entry.version === "string" ? entry.version.trim() || null : null,
+        summary: typeof entry.summary === "string" ? entry.summary.trim() || null : null,
+        path: typeof entry.path === "string" ? entry.path.trim() || null : paths[0] || null,
+        paths,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function readDesiredPackages(state) {
+  return normalizePackageList(state?.desiredPackages);
+}
+
+function readInstalledPackages(state) {
+  return parseInstalledPackages(state?.installedPackages);
+}
+
+const packageManagerType = detectPackageManager();
+let packageInstallPromise = null;
+
+async function runAptCommand(args, { timeout = 0 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("apt-get", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timer = null;
+
+    const finish = (err, result) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (err) {
+        err.stdout = stdout;
+        err.stderr = stderr;
+        reject(err);
+        return;
+      }
+      resolve({ stdout, stderr, ...(result || {}) });
+    };
+
+    if (timeout > 0) {
+      timer = setTimeout(() => {
+        child.kill("SIGTERM");
+        finish(new Error(`apt-get ${args.join(" ")} timed out`));
+      }, timeout);
+    }
+
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+    child.on("error", (err) => finish(err));
+    child.on("close", (code) => {
+      if (code === 0) {
+        finish(null, { code });
+      } else {
+        finish(new Error(`apt-get ${args.join(" ")} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function getInstalledPackageDetails(packageNames = []) {
+  const normalizedPackages = normalizePackageList(packageNames);
+  if (!normalizedPackages.length || packageManagerType !== "apt") {
+    return [];
+  }
+
+  const details = [];
+  for (const packageName of normalizedPackages) {
+    try {
+      const { stdout: versionStdout } = await execFileAsync(
+        "dpkg-query",
+        ["-W", "-f=${Package}\t${Version}\n", packageName],
+        { timeout: 5000 },
+      );
+      const versionLine = versionStdout.trim().split(/\r?\n/).find(Boolean) || "";
+      if (!versionLine) {
+        continue;
+      }
+      const parts = versionLine.split("\t");
+      const version = parts[1] ? parts[1].trim() : null;
+
+      let summary = null;
+      try {
+        const { stdout: showStdout } = await execFileAsync("apt-cache", ["show", packageName], { timeout: 5000 });
+        const summaryLine = showStdout.split(/\r?\n/).find((line) => line.startsWith("Description: "));
+        summary = summaryLine ? summaryLine.replace("Description: ", "").trim() || null : null;
+      } catch (err) {
+        summary = null;
+      }
+
+      let paths = [];
+      try {
+        const { stdout: listStdout } = await execFileAsync("dpkg", ["-L", packageName], { timeout: 5000 });
+        paths = Array.from(
+          new Set(
+            listStdout
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter((line) => line.startsWith("/usr/bin/") || line.startsWith("/usr/local/bin/") || line.startsWith("/bin/")),
+          ),
+        ).slice(0, 8);
+      } catch (err) {
+        paths = [];
+      }
+
+      details.push({
+        name: packageName,
+        version: version || null,
+        summary,
+        path: paths[0] || null,
+        paths,
+      });
+    } catch (err) {
+      // Ignore packages that are not currently installed.
+    }
+  }
+
+  return details.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function refreshInstalledPackages() {
+  const desiredPackages = readDesiredPackages(persistedState);
+  const installedPackages = await getInstalledPackageDetails(desiredPackages);
+  persistedState.installedPackages = installedPackages;
+  persistState();
+  return installedPackages;
+}
+
+async function installDesiredPackages(packageNames) {
+  const normalizedPackages = normalizePackageList(packageNames);
+  if (!normalizedPackages.length) {
+    return {
+      packageManager: packageManagerType,
+      desiredPackages: readDesiredPackages(persistedState),
+      installedPackages: readInstalledPackages(persistedState),
+      changed: false,
+    };
+  }
+  if (packageManagerType !== "apt") {
+    throw new Error("Persistent package installs are currently supported only on Linux runners with apt.");
+  }
+
+  const mergedDesired = Array.from(new Set([...readDesiredPackages(persistedState), ...normalizedPackages]));
+  persistedState.desiredPackages = mergedDesired;
+  persistState();
+
+  if (!packageInstallPromise) {
+    packageInstallPromise = (async () => {
+      await runAptCommand(["update"], { timeout: 120000 });
+      await runAptCommand(["install", "-y", "--no-install-recommends", ...mergedDesired], { timeout: 300000 });
+      const installedPackages = await getInstalledPackageDetails(mergedDesired);
+      persistedState.installedPackages = installedPackages;
+      persistState();
+      return installedPackages;
+    })();
+  }
+
+  try {
+    const installedPackages = await packageInstallPromise;
+    return {
+      packageManager: packageManagerType,
+      desiredPackages: mergedDesired,
+      installedPackages,
+      changed: true,
+    };
+  } finally {
+    packageInstallPromise = null;
+  }
+}
+
+async function searchAptPackages(query) {
+  if (packageManagerType !== "apt") {
+    return [];
+  }
+  const normalizedQuery = typeof query === "string" ? query.trim() : "";
+  if (!normalizedQuery) {
+    return [];
+  }
+  const { stdout } = await execFileAsync("apt-cache", ["search", "--names-only", normalizedQuery], { timeout: 10000, maxBuffer: 1024 * 1024 * 4 });
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 25)
+    .map((line) => {
+      const [namePart, ...rest] = line.split(" - ");
+      const name = normalizePackageName(namePart || "");
+      if (!name) {
+        return null;
+      }
+      return {
+        name,
+        summary: rest.join(" - ").trim() || null,
+      };
+    })
+    .filter(Boolean);
+}
+
 function normalizeUrl(value) {
   if (Array.isArray(value)) {
     if (!value.length) return "";
@@ -419,6 +703,8 @@ function writeStateToDisk(file, payload) {
 }
 
 const persistedState = config.stateFile ? readStateFromDisk(config.stateFile) : {};
+persistedState.desiredPackages = readDesiredPackages(persistedState);
+persistedState.installedPackages = readInstalledPackages(persistedState);
 if (inMemoryState.secretSource === "state" && persistedState.secret) {
   inMemoryState.secret = persistedState.secret;
 }
@@ -489,6 +775,8 @@ function persistState() {
         acc[key] = config.runtimeExecutables[key] || null;
         return acc;
       }, {}),
+      desiredPackages: readDesiredPackages(persistedState),
+      installedPackages: readInstalledPackages(persistedState),
     };
     writeStateToDisk(config.stateFile, payload);
     return;
@@ -512,6 +800,8 @@ function persistState() {
       acc[key] = config.runtimeExecutables[key] || null;
       return acc;
     }, {}),
+    desiredPackages: readDesiredPackages(persistedState),
+    installedPackages: readInstalledPackages(persistedState),
   };
   writeStateToDisk(config.stateFile, payload);
 }
@@ -625,6 +915,23 @@ function refreshRuntimeDetections() {
   }
 }
 
+async function ensureDesiredSystemPackages() {
+  if (packageManagerType !== "apt") {
+    return;
+  }
+
+  const desiredPackages = readDesiredPackages(persistedState);
+  if (!desiredPackages.length) {
+    return;
+  }
+
+  try {
+    await installDesiredPackages(desiredPackages);
+  } catch (err) {
+    console.error("[runner] Failed to re-install persisted apt packages", err);
+  }
+}
+
 async function ensureDirectories() {
   const targetDirs = [config.scriptsDir, config.workdirDir, path.dirname(config.stateFile || "")];
   await Promise.all(
@@ -723,6 +1030,9 @@ function buildRegistrationPayload() {
   if (config.timeoutMs !== null) {
     payload.body.timeoutMs = config.timeoutMs;
   }
+  payload.body.packageManager = packageManagerType;
+  payload.body.desiredPackages = readDesiredPackages(persistedState);
+  payload.body.installedPackages = readInstalledPackages(persistedState);
   return payload;
 }
 
@@ -861,8 +1171,77 @@ app.get("/status", (req, res) => {
       scriptsDir: config.scriptsDir,
       workdirDir: config.workdirDir,
       secretManagedByEnv: !secretIsConfigurable(),
+      packageManager: packageManagerType,
+      desiredPackages: readDesiredPackages(persistedState),
     },
   });
+});
+
+function requireRunnerSecret(req, res) {
+  const requestSecret = normalizeUrl(req.headers["x-automn-runner-secret"]);
+  const configuredSecret = getSecret();
+  if (!configuredSecret || requestSecret !== configuredSecret) {
+    res.status(401).json({ error: "Invalid runner secret" });
+    return false;
+  }
+  return true;
+}
+
+app.get("/api/system/packages", (req, res) => {
+  if (!requireRunnerSecret(req, res)) {
+    return;
+  }
+  res.json({
+    packageManager: packageManagerType,
+    supported: packageManagerType === "apt",
+    desiredPackages: readDesiredPackages(persistedState),
+    installedPackages: readInstalledPackages(persistedState),
+    recommendedPackages: RECOMMENDED_SYSTEM_PACKAGES,
+  });
+});
+
+app.get("/api/system/packages/search", async (req, res) => {
+  if (!requireRunnerSecret(req, res)) {
+    return;
+  }
+  if (packageManagerType !== "apt") {
+    res.status(400).json({ error: "Runner does not support apt package installation." });
+    return;
+  }
+
+  const query = typeof req.query?.q === "string" ? req.query.q.trim() : "";
+  if (!query) {
+    res.status(400).json({ error: "Search query is required" });
+    return;
+  }
+
+  try {
+    const results = await searchAptPackages(query);
+    res.json({ results });
+  } catch (err) {
+    console.error("[runner] Failed to search apt packages", err);
+    res.status(500).json({ error: err?.message || "Failed to search apt packages" });
+  }
+});
+
+app.post("/api/system/packages/install", async (req, res) => {
+  if (!requireRunnerSecret(req, res)) {
+    return;
+  }
+
+  const packages = normalizePackageList(Array.isArray(req.body?.packages) ? req.body.packages : []);
+  if (!packages.length) {
+    res.status(400).json({ error: "At least one package is required" });
+    return;
+  }
+
+  try {
+    const result = await installDesiredPackages(packages);
+    res.json(result);
+  } catch (err) {
+    console.error("[runner] Failed to install apt packages", err);
+    res.status(500).json({ error: err?.stderr || err?.message || "Failed to install apt packages" });
+  }
 });
 
 function renderPage({ title, body }) {

--- a/server.js
+++ b/server.js
@@ -140,6 +140,21 @@ const RUNNER_STATUS = Object.freeze({
 
 const RUNNER_HEALTH_WINDOW_MS = 2 * 60 * 1000;
 const MIN_RUNNER_SECRET_LENGTH = 12;
+const RUNNER_RECOMMENDED_PACKAGES = Object.freeze([
+  "chromium",
+  "curl",
+  "wget",
+  "git",
+  "zip",
+  "unzip",
+  "jq",
+  "ffmpeg",
+  "poppler-utils",
+  "default-mysql-client",
+  "sqlite3",
+  "postgresql-client",
+  "openssh-client",
+]);
 const SCHEDULER_ENABLED_SETTING_KEY = "scheduler_enabled";
 const SCHEDULER_POLL_INTERVAL_MS = 30 * 1000;
 
@@ -386,6 +401,9 @@ function sanitizeRunnerHost(host) {
         ? { ...host.runnerRuntimes }
         : {},
     minimumHostVersion: host.minimumHostVersion || null,
+    packageManager: host.packageManager || null,
+    desiredPackages: Array.isArray(host.desiredPackages) ? [...host.desiredPackages] : [],
+    installedPackages: Array.isArray(host.installedPackages) ? host.installedPackages.map((pkg) => ({ ...pkg, paths: Array.isArray(pkg?.paths) ? [...pkg.paths] : [] })) : [],
     hostVersion: HOST_VERSION,
     minimumRunnerVersion: MINIMUM_RUNNER_VERSION,
     adminOnly: Boolean(host.adminOnly),
@@ -2902,14 +2920,11 @@ async function applyPackageStatuses(scriptId, statuses = []) {
   }
 }
 
-async function requestRunnerPackageStatus({
-  runnerHostId,
-  scriptId,
-  packages,
-  installMissing = true,
-}) {
-  if (!runnerHostId || !Array.isArray(packages) || !packages.length) {
-    return { packages: [] };
+async function requestRunnerEndpoint({ runnerHostId, pathname, method = "GET", body = undefined }) {
+  if (!runnerHostId) {
+    const error = new Error("Runner host id is required");
+    error.code = "runner_missing";
+    throw error;
   }
 
   if (!httpFetch) {
@@ -2927,24 +2942,25 @@ async function requestRunnerPackageStatus({
     throw error;
   }
 
-  const target = new URL("/api/packages/status", host.endpoint);
+  const target = new URL(pathname, host.endpoint);
   const headers = {
-    "content-type": "application/json",
     accept: "application/json",
     ...(host.headers || {}),
   };
 
+  const requestOptions = {
+    method,
+    headers,
+  };
+
+  if (body !== undefined) {
+    headers["content-type"] = "application/json";
+    requestOptions.body = JSON.stringify(body);
+  }
+
   let response;
   try {
-    response = await httpFetch(target.toString(), {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        scriptId,
-        packages,
-        installMissing,
-      }),
-    });
+    response = await httpFetch(target.toString(), requestOptions);
   } catch (err) {
     const error = new Error(
       err?.message
@@ -2963,27 +2979,52 @@ async function requestRunnerPackageStatus({
     bodyText = "";
   }
 
+  let payload = null;
+  if (bodyText) {
+    try {
+      payload = JSON.parse(bodyText);
+    } catch (err) {
+      const error = new Error("Runner returned an invalid JSON response");
+      error.cause = err;
+      throw error;
+    }
+  }
+
   if (!response.ok) {
-    const message = bodyText
-      ? `Runner responded with ${response.status}: ${bodyText}`
-      : `Runner responded with ${response.status}`;
+    const message = payload?.error
+      ? `Runner responded with ${response.status}: ${payload.error}`
+      : bodyText
+        ? `Runner responded with ${response.status}: ${bodyText}`
+        : `Runner responded with ${response.status}`;
     const error = new Error(message);
     error.status = response.status;
+    error.data = payload;
     throw error;
   }
 
-  if (!bodyText) {
+  return payload && typeof payload === "object" ? payload : {};
+}
+
+async function requestRunnerPackageStatus({
+  runnerHostId,
+  scriptId,
+  packages,
+  installMissing = true,
+}) {
+  if (!runnerHostId || !Array.isArray(packages) || !packages.length) {
     return { packages: [] };
   }
 
-  try {
-    const payload = JSON.parse(bodyText);
-    return payload && typeof payload === "object" ? payload : { packages: [] };
-  } catch (err) {
-    const error = new Error("Runner returned an invalid JSON response");
-    error.cause = err;
-    throw error;
-  }
+  return requestRunnerEndpoint({
+    runnerHostId,
+    pathname: "/api/packages/status",
+    method: "POST",
+    body: {
+      scriptId,
+      packages,
+      installMissing,
+    },
+  });
 }
 
 async function synchronizeScriptPackages({
@@ -4473,6 +4514,101 @@ app.post("/api/settings/runner-hosts", requireAdmin, async (req, res) => {
   }
 });
 
+app.get("/api/settings/runner-hosts/:id/system-packages", requireAdmin, async (req, res) => {
+  const hostId = typeof req.params.id === "string" ? req.params.id.trim() : "";
+  if (!hostId) {
+    res.status(400).json({ error: "Runner host id is required" });
+    return;
+  }
+
+  try {
+    const payload = await requestRunnerEndpoint({
+      runnerHostId: hostId,
+      pathname: "/api/system/packages",
+    });
+    const existing = await db.getRunnerHostById(hostId, { includeSecret: true });
+    const merged = existing
+      ? await db.updateRunnerHostStatus(hostId, {
+          packageManager: payload?.packageManager || existing.packageManager || null,
+          desiredPackages: Array.isArray(payload?.desiredPackages) ? payload.desiredPackages : existing.desiredPackages || [],
+          installedPackages: Array.isArray(payload?.installedPackages) ? payload.installedPackages : existing.installedPackages || [],
+        })
+      : null;
+    res.json({
+      ...payload,
+      runnerHost: merged ? sanitizeRunnerHost(merged) : null,
+      recommendedPackages: RUNNER_RECOMMENDED_PACKAGES,
+    });
+  } catch (err) {
+    console.error("Failed to load runner system packages", err);
+    res.status(err?.status || 500).json({
+      error: err?.data?.error || err?.message || "Failed to load runner system packages",
+    });
+  }
+});
+
+app.get("/api/settings/runner-hosts/:id/system-packages/search", requireAdmin, async (req, res) => {
+  const hostId = typeof req.params.id === "string" ? req.params.id.trim() : "";
+  const query = typeof req.query?.q === "string" ? req.query.q.trim() : "";
+  if (!hostId) {
+    res.status(400).json({ error: "Runner host id is required" });
+    return;
+  }
+  if (!query) {
+    res.status(400).json({ error: "Search query is required" });
+    return;
+  }
+
+  try {
+    const payload = await requestRunnerEndpoint({
+      runnerHostId: hostId,
+      pathname: `/api/system/packages/search?q=${encodeURIComponent(query)}`,
+    });
+    res.json(payload);
+  } catch (err) {
+    console.error("Failed to search runner system packages", err);
+    res.status(err?.status || 500).json({
+      error: err?.data?.error || err?.message || "Failed to search runner system packages",
+    });
+  }
+});
+
+app.post("/api/settings/runner-hosts/:id/system-packages/install", requireAdmin, async (req, res) => {
+  const hostId = typeof req.params.id === "string" ? req.params.id.trim() : "";
+  const packages = Array.isArray(req.body?.packages) ? req.body.packages : [];
+  if (!hostId) {
+    res.status(400).json({ error: "Runner host id is required" });
+    return;
+  }
+
+  try {
+    const payload = await requestRunnerEndpoint({
+      runnerHostId: hostId,
+      pathname: "/api/system/packages/install",
+      method: "POST",
+      body: { packages },
+    });
+    const existing = await db.getRunnerHostById(hostId, { includeSecret: true });
+    const merged = existing
+      ? await db.updateRunnerHostStatus(hostId, {
+          packageManager: payload?.packageManager || existing.packageManager || null,
+          desiredPackages: Array.isArray(payload?.desiredPackages) ? payload.desiredPackages : existing.desiredPackages || [],
+          installedPackages: Array.isArray(payload?.installedPackages) ? payload.installedPackages : existing.installedPackages || [],
+        })
+      : null;
+    res.json({
+      ...payload,
+      runnerHost: merged ? sanitizeRunnerHost(merged) : null,
+      recommendedPackages: RUNNER_RECOMMENDED_PACKAGES,
+    });
+  } catch (err) {
+    console.error("Failed to install runner system packages", err);
+    res.status(err?.status || 500).json({
+      error: err?.data?.error || err?.message || "Failed to install runner system packages",
+    });
+  }
+});
+
 app.post(
   "/api/settings/runner-hosts/:id/rotate-secret",
   requireAdmin,
@@ -5269,6 +5405,39 @@ app.post("/api/settings/runner-hosts/:id/register", async (req, res) => {
   const normalizedRunnerUptime =
     Number.isFinite(parsedUptime) && parsedUptime >= 0 ? parsedUptime : null;
   const normalizedRuntimes = normalizeRunnerRuntimesPayload(req.body?.runtimes);
+  const normalizedPackageManager =
+    typeof req.body?.packageManager === "string" && req.body.packageManager.trim()
+      ? req.body.packageManager.trim()
+      : null;
+  const normalizedDesiredPackages = Array.isArray(req.body?.desiredPackages)
+    ? req.body.desiredPackages
+        .map((pkg) => (typeof pkg === "string" ? pkg.trim() : ""))
+        .filter(Boolean)
+    : [];
+  const normalizedInstalledPackages = Array.isArray(req.body?.installedPackages)
+    ? req.body.installedPackages
+        .map((entry) => {
+          if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+            return null;
+          }
+          const name = typeof entry.name === "string" ? entry.name.trim() : "";
+          if (!name) {
+            return null;
+          }
+          return {
+            name,
+            version: typeof entry.version === "string" ? entry.version.trim() || null : null,
+            summary: typeof entry.summary === "string" ? entry.summary.trim() || null : null,
+            path: typeof entry.path === "string" ? entry.path.trim() || null : null,
+            paths: Array.isArray(entry.paths)
+              ? entry.paths
+                  .map((value) => (typeof value === "string" ? value.trim() : ""))
+                  .filter(Boolean)
+              : [],
+          };
+        })
+        .filter(Boolean)
+    : [];
 
   const now = new Date().toISOString();
 
@@ -5288,6 +5457,9 @@ app.post("/api/settings/runner-hosts/:id/register", async (req, res) => {
       runnerUptime: normalizedRunnerUptime,
       runnerRuntimes: normalizedRuntimes,
       minimumHostVersion: normalizedMinimumHostVersion,
+      packageManager: normalizedPackageManager,
+      desiredPackages: normalizedDesiredPackages,
+      installedPackages: normalizedInstalledPackages,
       clearDisabledAt: true,
     });
   } catch (err) {


### PR DESCRIPTION
### Motivation

- Provide administrators the ability to install persistent OS packages on runners and surface those applications in the host UI so admins can review versions/paths and manage installs centrally.
- Persist desired system packages and discovered installed application metadata across runner restarts so installs are re-applied and visible to the host.

### Description

- Added persistent runner package metadata to the schema and mapping layer by adding `package_manager`, `desired_packages`, and `installed_packages` to runner host records and plumbing parse/serialize helpers in `db.js`.
- Implemented host API endpoints to proxy and persist runner package state: `GET /api/settings/runner-hosts/:id/system-packages`, `GET /api/settings/runner-hosts/:id/system-packages/search`, and `POST /api/settings/runner-hosts/:id/system-packages/install`, which call a generic runner proxy helper and update runner host records; updated `sanitizeRunnerHost` to include package fields (`server.js`).
- Extended runner agent with apt-based package management (Linux/apt only): secure endpoints `GET /api/system/packages`, `GET /api/system/packages/search`, and `POST /api/system/packages/install` that require the runner secret, a package search implementation using `apt-cache`, and installation via `apt-get` with persisted `desiredPackages` and `installedPackages` in runner state; runner discovers installed package `version`, `path`, and `paths` and re-applies desired packages on startup (`runner/service.js`).
- Updated admin UI (`frontend/src/components/SettingsRunnerHosts.jsx`) to show an "Additional applications" panel per-runner with: recommended buttons, an apt search box, install actions, persisted package chips, and an installed-apps table showing package name, version, and path.
- Added a curated recommended package list (e.g. `chromium`, `curl`, `wget`, `git`, `zip`, `unzip`, `jq`, `ffmpeg`, `poppler-utils`, `default-mysql-client`, `sqlite3`, `postgresql-client`, `openssh-client`) surfaced in both host and runner code.
- Security and compatibility notes: runner install/search endpoints are protected by the runner secret and persistent installs currently supported only on Linux runners with `apt`.

### Testing

- Ran `node --check server.js` and `node --check runner/service.js` to validate syntax; both checks passed.
- Built the frontend with `npm --prefix frontend run build`; the production build completed successfully.
- Manual smoke: the runner build and host server checks passed after fixes; no automated test suite exists in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba81f22ec8832688114c145c71ae69)